### PR TITLE
Rename serve_local.sh to start_local.sh, default port 8081

### DIFF
--- a/start_local.sh
+++ b/start_local.sh
@@ -3,7 +3,7 @@
 # Local server script for serving the dapp
 # This allows Google Places API to work (requires http:// not file://)
 
-PORT=${1:-8000}
+PORT=${1:-8081}
 
 # Function to check if port is in use
 check_port() {


### PR DESCRIPTION
## Summary
- Renames `serve_local.sh` → `start_local.sh` to match standardized local-dev script name (agroverse_shop, truesight_me)
- Changes default port from 8000 → 8081 so each repo has a distinct predictable port:
  - agroverse_shop → 8000
  - truesight_me → 8080
  - dapp → 8081
- Port is still overridable via positional arg (e.g. `./start_local.sh 9000`)

## Test plan
- [x] No in-repo references to old filename found

🤖 Generated with [Claude Code](https://claude.com/claude-code)