### PR TITLE
feat(routes): centralize endpoints in routes.js + migrate submit_feedback POC

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -1,0 +1,20 @@
+(function (global) {
+  // Single source of truth for every remote endpoint the DApp calls.
+  // Works in both window (pages) and self (service worker via importScripts).
+  // Schemas live in tokenomics/API_ENDPOINTS.md — keep that doc in sync when
+  // adding or changing any URL here.
+  global.Routes = {
+    edgar: {
+      base:   'https://edgar.truesight.me',
+      ping:   'https://edgar.truesight.me/ping',
+      submit: 'https://edgar.truesight.me/dao/submit_contribution',
+    },
+    gas: {
+      assetVerify: 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec',
+      qrCodes:     'https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec',
+      daoForms:    'https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec',
+      proposals:   'https://script.google.com/a/macros/agroverse.shop/s/AKfycbzgNstwRX1dWo17Dxny0t1ipJ6yLX02bTD_cKRuHr5RPJPemNVTj25mFhKo4UmR5Z7BIg/exec',
+      feedback:    'https://script.google.com/macros/s/AKfycbz3FQgXLaEc4KNq9fhCCFbf677OIcEMjVq_HjcgttMfCNWk7QWaCeTEq0xc5aRRbduFdg/exec',
+    },
+  };
+})(typeof self !== 'undefined' ? self : this);

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,6 @@
-const CACHE_NAME = 'qr-scanner-cache-v2';
+importScripts('./routes.js');
+
+const CACHE_NAME = 'qr-scanner-cache-v3';
 const URLS_TO_CACHE = [
   // HTML pages
   './',
@@ -13,19 +15,21 @@ const URLS_TO_CACHE = [
   './report_sales.html',
   './report_tree_planting.html',
   './scanner.html',
+  './submit_feedback.html',
   './verify_request.html',
   './withdraw_voting_rights.html',
   // Scripts
   './menu.js',
+  './routes.js',
   './service-worker.js',
   // External libraries
   'https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.min.js',
   // Assets
   './assets/brazil.png',
   './assets/usa.png',
-  // Google Apps Script API endpoints (dynamic data)                                                                 
-  'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec',
-  'https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec'
+  // Google Apps Script API endpoints — sourced from Routes for a single source of truth
+  self.Routes.gas.assetVerify,
+  self.Routes.gas.daoForms
 ];
 
 // Install event: cache essential assets
@@ -60,8 +64,11 @@ self.addEventListener('fetch', event => {
     );
     return;
   }
-  // Handle Google Apps Script API calls: network-first with cache fallback
-  if (url.origin === 'https://script.google.com' && url.pathname.startsWith('/macros/s/')) {
+  // Handle Google Apps Script API calls: network-first with cache fallback.
+  // Matches both '/macros/s/<id>/exec' and the workspace-scoped
+  // '/a/macros/<domain>/s/<id>/exec' variant used by the Proposals GAS.
+  if (url.origin === 'https://script.google.com'
+      && (url.pathname.startsWith('/macros/s/') || url.pathname.startsWith('/a/macros/'))) {
     event.respondWith(
       fetch(request)
         .then(response => {

--- a/submit_feedback.html
+++ b/submit_feedback.html
@@ -15,6 +15,7 @@
     
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
+    <script src="./routes.js"></script>
     <script src="./menu.js"></script>
     <script src="./tdg_balance.js"></script>
 
@@ -276,8 +277,12 @@
     </div>
 
     <script>
-        const FEEDBACK_API_ENDPOINT = 'https://script.google.com/macros/s/AKfycbz3FQgXLaEc4KNq9fhCCFbf677OIcEMjVq_HjcgttMfCNWk7QWaCeTEq0xc5aRRbduFdg/exec';
-        const API_ENDPOINT = 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+        // Prefer centralized Routes (see routes.js); fall back to hardcoded URLs
+        // so the page still works if routes.js fails to load (offline/old cache).
+        const FEEDBACK_API_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.feedback)
+            || 'https://script.google.com/macros/s/AKfycbz3FQgXLaEc4KNq9fhCCFbf677OIcEMjVq_HjcgttMfCNWk7QWaCeTEq0xc5aRRbduFdg/exec';
+        const API_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
+            || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
         let contributorName = '';
         let isPostSubmission = false;
 


### PR DESCRIPTION
## Summary
- Introduce `dapp/routes.js` as the single source of truth for every Edgar and Google Apps Script endpoint the DApp calls. IIFE bound to `self` so service worker and page scripts share the same `Routes` object.
- Migrate `submit_feedback.html` as the proof-of-concept; both GAS URL constants read from `window.Routes.gas.*` with the prior hardcoded URL kept as a fallback.
- `service-worker.js`: import `routes.js` via `importScripts`, source the GAS pre-cache list from `Routes`, bump cache `v2` → `v3`, pre-cache the new asset, and extend the fetch-handler matcher to also cover `/a/macros/<domain>/s/...` URLs (Proposals GAS) that were previously bypassed.

Remaining pages will be migrated per-module in follow-up PRs (Contributions, Identity & Governance, Inventory & Sales, Sunmint, misc). Schemas for every endpoint live in `tokenomics/API_ENDPOINTS.md` → **DApp-Called GAS Endpoints**.

## Test plan
- [x] `node --check` passes on `routes.js` and `service-worker.js`
- [x] `routes.js` served over HTTP returns 200, exposes `Routes.edgar` + `Routes.gas` with the expected keys in a fresh page and in a SW-like global
- [x] Local smoke test: `submit_feedback.html` loads, `window.Routes.gas.feedback` + `assetVerify` resolve, `caches.keys()` shows `qr-scanner-cache-v3`
- [ ] Reviewer: reload `submit_feedback.html` and confirm signature verification + feedback submission still work end-to-end
- [ ] Reviewer: DevTools → Application → Service Workers: confirm worker activates and pre-cache URL count matches `URLS_TO_CACHE.length`

🤖 Generated with [Claude Code](https://claude.com/claude-code)