### PR TITLE
feat(routes): migrate Contributions module (report_contribution.html)

### DIFF
--- a/report_contribution.html
+++ b/report_contribution.html
@@ -15,6 +15,7 @@
     
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
+    <script src="./routes.js"></script>
     <script src="./menu.js"></script>
     <script src="./tdg_balance.js"></script>
 
@@ -430,7 +431,14 @@
             submitBtn.textContent = isPostSubmission ? 'Submit Another Contribution' : 'Submit Contribution Report';
         }        
 
-        const API_ENDPOINT = 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+        const API_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
+            || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+        const DAO_FORMS_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.daoForms)
+            || 'https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec';
+        const EDGAR_PING = (window.Routes && window.Routes.edgar && window.Routes.edgar.ping)
+            || 'https://edgar.truesight.me/ping';
+        const EDGAR_SUBMIT = (window.Routes && window.Routes.edgar && window.Routes.edgar.submit)
+            || 'https://edgar.truesight.me/dao/submit_contribution';
         const REPO_BASE_URL = 'https://github.com/TrueSightDAO/.github/tree/main/assets/';
         let contributorName = '';
         let allContributors = [];
@@ -624,7 +632,7 @@
 
         async function loadContributors() {
             try {
-                const res = await fetch('https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec?recipients=true');
+                const res = await fetch(`${DAO_FORMS_ENDPOINT}?recipients=true`);
                 allContributors = await res.json();
                 updateContributorAutocomplete();
                 
@@ -759,7 +767,7 @@
         async function isOnline() {
             if (!navigator.onLine) return false;
             try {
-                const response = await fetch('https://edgar.truesight.me/ping', { method: 'HEAD', timeout: 5000 });
+                const response = await fetch(EDGAR_PING, { method: 'HEAD', timeout: 5000 });
                 return response.ok;
             } catch {
                 return false;
@@ -1014,7 +1022,7 @@
                         formData.append('attachment', file, fileName);
                     }
 
-                    const resp = await fetch('https://edgar.truesight.me/dao/submit_contribution', {
+                    const resp = await fetch(EDGAR_SUBMIT, {
                         method: 'POST',
                         body: formData
                     });


### PR DESCRIPTION
## Summary
- Migrate `report_contribution.html` to the centralized `Routes` object from `routes.js`.
- Four hardcoded endpoints replaced with `Routes.*` lookups with hardcoded fallbacks: `Routes.gas.assetVerify`, `Routes.gas.daoForms`, `Routes.edgar.ping`, `Routes.edgar.submit`.
- Completes the Contributions module (submit_feedback was done in #159).

## Test plan
- [ ] Reviewer: reload `report_contribution.html`, confirm signature verification works, contributor autocomplete populates, connectivity probe succeeds, and a test contribution submits successfully.
- [ ] Check DevTools console for any `window.Routes` undefined errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)