### PR TITLE
feat(routes): migrate Identity & Governance module

### DIFF
--- a/create_proposal.html
+++ b/create_proposal.html
@@ -15,6 +15,7 @@
     
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
+    <script src="./routes.js"></script>
     <script src="./menu.js"></script>
     <script src="./tdg_balance.js"></script>
     <style>
@@ -483,8 +484,12 @@
 
     <script>
         // Configuration - Google Apps Script web app URLs
-        const API_ENDPOINT = 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
-        const WEB_APP_URL = 'https://script.google.com/a/macros/agroverse.shop/s/AKfycbzgNstwRX1dWo17Dxny0t1ipJ6yLX02bTD_cKRuHr5RPJPemNVTj25mFhKo4UmR5Z7BIg/exec';
+        const API_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
+            || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+        const WEB_APP_URL = (window.Routes && window.Routes.gas && window.Routes.gas.proposals)
+            || 'https://script.google.com/a/macros/agroverse.shop/s/AKfycbzgNstwRX1dWo17Dxny0t1ipJ6yLX02bTD_cKRuHr5RPJPemNVTj25mFhKo4UmR5Z7BIg/exec';
+        const EDGAR_SUBMIT = (window.Routes && window.Routes.edgar && window.Routes.edgar.submit)
+            || 'https://edgar.truesight.me/dao/submit_contribution';
         
         // Helper function for base64 encoding
         function arrayBufferToBase64(buffer) {
@@ -682,7 +687,7 @@ Verify submission here: https://dapp.truesight.me/verify_request.html`;
                 const formData = new FormData();
                 formData.append('text', shareText);
 
-                const response = await fetch('https://edgar.truesight.me/dao/submit_contribution', {
+                const response = await fetch(EDGAR_SUBMIT, {
                     method: 'POST',
                     body: formData
                 });

--- a/create_signature.html
+++ b/create_signature.html
@@ -15,6 +15,7 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
   
+  <script src="./routes.js"></script>
   <script src="./menu.js"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/edgar_payload_helper.js"></script>
@@ -403,7 +404,7 @@
         }
         return 'http://localhost:3000';
       }
-      return 'https://edgar.truesight.me';
+      return (window.Routes && window.Routes.edgar && window.Routes.edgar.base) || 'https://edgar.truesight.me';
     })();
     const EDGAR_SUBMIT_URL = `${EDGAR_BASE}/dao/submit_contribution`;
     const EDGAR_CHECK_SIGNATURE_URL = `${EDGAR_BASE}/dao/check_digital_signature`;

--- a/notarize.html
+++ b/notarize.html
@@ -15,6 +15,7 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
 
+  <script src="./routes.js"></script>
   <script src="./menu.js"></script>
   <script src="./tdg_balance.js"></script>
   <style>
@@ -331,7 +332,12 @@
   </div>
 
   <script>
-    const API_ENDPOINT = 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+    const API_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
+        || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+    const EDGAR_PING = (window.Routes && window.Routes.edgar && window.Routes.edgar.ping)
+        || 'https://edgar.truesight.me/ping';
+    const EDGAR_SUBMIT = (window.Routes && window.Routes.edgar && window.Routes.edgar.submit)
+        || 'https://edgar.truesight.me/dao/submit_contribution';
     const REPO_BASE_URL = 'https://github.com/TrueSightDAO/notarizations/tree/main/';
     let latitude = null;
     let longitude = null;
@@ -365,7 +371,7 @@
       // Check Edgar production endpoint
       if (!navigator.onLine) return false;
       try {
-        const response = await fetch('https://edgar.truesight.me/ping', { method: 'HEAD', timeout: 5000 });
+        const response = await fetch(EDGAR_PING, { method: 'HEAD', timeout: 5000 });
         return response.ok;
       } catch {
         return false;
@@ -709,7 +715,7 @@
             formData.append('text', shareText);
             formData.append('attachment', file, fileName);
 
-            const resp = await fetch('https://edgar.truesight.me/dao/submit_contribution', {
+            const resp = await fetch(EDGAR_SUBMIT, {
               method: 'POST',
               body: formData
             });

--- a/review_proposal.html
+++ b/review_proposal.html
@@ -15,6 +15,7 @@
     
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
+    <script src="./routes.js"></script>
     <script src="./menu.js"></script>
     <script src="./tdg_balance.js"></script>
     <style>
@@ -575,8 +576,12 @@
 
     <script>
         // Configuration - Google Apps Script web app URL
-        const WEB_APP_URL = 'https://script.google.com/a/macros/agroverse.shop/s/AKfycbzgNstwRX1dWo17Dxny0t1ipJ6yLX02bTD_cKRuHr5RPJPemNVTj25mFhKo4UmR5Z7BIg/exec';
-        const API_ENDPOINT = 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+        const WEB_APP_URL = (window.Routes && window.Routes.gas && window.Routes.gas.proposals)
+            || 'https://script.google.com/a/macros/agroverse.shop/s/AKfycbzgNstwRX1dWo17Dxny0t1ipJ6yLX02bTD_cKRuHr5RPJPemNVTj25mFhKo4UmR5Z7BIg/exec';
+        const API_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
+            || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+        const EDGAR_SUBMIT = (window.Routes && window.Routes.edgar && window.Routes.edgar.submit)
+            || 'https://edgar.truesight.me/dao/submit_contribution';
         
         let proposal = null;
         let currentVote = null;
@@ -912,7 +917,7 @@ Verify submission here: https://dapp.truesight.me/verify_request.html`;
                 const formData = new FormData();
                 formData.append('text', shareText);
 
-                const response = await fetch('https://edgar.truesight.me/dao/submit_contribution', {
+                const response = await fetch(EDGAR_SUBMIT, {
                     method: 'POST',
                     body: formData
                 });

--- a/verify_request.html
+++ b/verify_request.html
@@ -15,6 +15,7 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
 
+  <script src="./routes.js"></script>
   <script src="./menu.js"></script>
   <script src="./tdg_balance.js"></script>
   <style>
@@ -245,7 +246,8 @@ Request Transaction ID: PV0ZZI3FKJJPqjfaqWltHPgmka+pWfFkNnXlTILNNOnpp9hrlewy7SMH
   </div>
 
   <script>
-    const API_ENDPOINT = 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+    const API_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
+        || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
 
     async function verifyRequest() {
       const requestText = document.getElementById('requestInput').value.trim();

--- a/view_open_proposals.html
+++ b/view_open_proposals.html
@@ -15,6 +15,7 @@
     
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
+    <script src="./routes.js"></script>
     <script src="./menu.js"></script>
     <script src="./tdg_balance.js"></script>
 
@@ -293,7 +294,8 @@
 
     <script>
         // Configuration - Google Apps Script web app URL
-        const WEB_APP_URL = 'https://script.google.com/a/macros/agroverse.shop/s/AKfycbzgNstwRX1dWo17Dxny0t1ipJ6yLX02bTD_cKRuHr5RPJPemNVTj25mFhKo4UmR5Z7BIg/exec';
+        const WEB_APP_URL = (window.Routes && window.Routes.gas && window.Routes.gas.proposals)
+            || 'https://script.google.com/a/macros/agroverse.shop/s/AKfycbzgNstwRX1dWo17Dxny0t1ipJ6yLX02bTD_cKRuHr5RPJPemNVTj25mFhKo4UmR5Z7BIg/exec';
         
         let proposals = [];
 

--- a/withdraw_voting_rights.html
+++ b/withdraw_voting_rights.html
@@ -14,6 +14,7 @@
   <meta property="og:type" content="website">
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
+  <script src="./routes.js"></script>
   <script src="./menu.js"></script>
   <script src="./tdg_balance.js"></script>
   <style>
@@ -465,7 +466,8 @@
   </div>
 
   <script>
-    const API_ENDPOINT = 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+    const API_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
+        || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
     const LEDGER_OFFCHAIN_BALANCE_URL = 'https://docs.google.com/spreadsheets/d/1GE7PUq-UT6x2rBN-Q2ksogbWpgyuh2SaxJyG_uEK6PU/edit?gid=2083442561';
     const BLOG_AUM_URL = 'https://truesight.me/blog/posts/understanding-assets-under-management-aum-truesight-dao-comprehensive-asset-tracking.html';
     let maxVotingRights = 0;


### PR DESCRIPTION
## Summary
Migrates 7 pages in the Identity & Governance module to read endpoint URLs from the centralized `Routes` object, each with a hardcoded fallback:

| Page | Routes keys wired |
|------|-------------------|
| `create_signature.html` | `Routes.edgar.base` (preserves `?edgar_base` / `?local_edgar` override) |
| `withdraw_voting_rights.html` | `Routes.gas.assetVerify` |
| `verify_request.html` | `Routes.gas.assetVerify` |
| `notarize.html` | `Routes.gas.assetVerify`, `Routes.edgar.ping`, `Routes.edgar.submit` |
| `view_open_proposals.html` | `Routes.gas.proposals` |
| `create_proposal.html` | `Routes.gas.assetVerify`, `Routes.gas.proposals`, `Routes.edgar.submit` |
| `review_proposal.html` | `Routes.gas.assetVerify`, `Routes.gas.proposals`, `Routes.edgar.submit` |

## Test plan
- [ ] Smoke test each page: signature verification works, where applicable proposal list / vote / create submit end-to-end
- [ ] `create_signature.html`: confirm `?edgar_base=http://127.0.0.1:3000` override still takes precedence over `Routes.edgar.base`
- [ ] `notarize.html`: confirm ping + submit both route through `Routes.edgar.*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)