### PR TITLE
feat(routes): migrate Inventory & Sales module

### DIFF
--- a/batch_qr_generator.html
+++ b/batch_qr_generator.html
@@ -14,6 +14,7 @@
     <meta property="og:type" content="website">
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
+    <script src="./routes.js"></script>
     <script src="./menu.js"></script>
     <script src="./tdg_balance.js"></script>
     
@@ -215,8 +216,12 @@
     </div>
 
     <script>
-        const API_ENDPOINT = 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
-        const GOOGLE_APPS_SCRIPT_URL = 'https://script.google.com/macros/s/AKfycbyGD0CDkvjo7K9O1gPnnqmdXvaJt9FM2v39HHqiDud5wwU6Mf41wwIOFS-NDD93xqoL/exec';
+        const API_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
+            || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+        const GOOGLE_APPS_SCRIPT_URL = (window.Routes && window.Routes.gas && window.Routes.gas.qrCodeGenerator)
+            || 'https://script.google.com/macros/s/AKfycbyGD0CDkvjo7K9O1gPnnqmdXvaJt9FM2v39HHqiDud5wwU6Mf41wwIOFS-NDD93xqoL/exec';
+        const EDGAR_SUBMIT = (window.Routes && window.Routes.edgar && window.Routes.edgar.submit)
+            || 'https://edgar.truesight.me/dao/submit_contribution';
         
         let currencies = [];
         let contributorName = '';
@@ -527,7 +532,7 @@ Verify submission here: https://dapp.truesight.me/verify_request.html`;
                 const formData = new FormData();
                 formData.append('text', shareText);
 
-                const response = await fetch('https://edgar.truesight.me/dao/submit_contribution', {
+                const response = await fetch(EDGAR_SUBMIT, {
                     method: 'POST',
                     body: formData
                 });

--- a/report_dao_expenses.html
+++ b/report_dao_expenses.html
@@ -15,6 +15,7 @@
     
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
+    <script src="./routes.js"></script>
     <script src="./menu.js"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./expense-form-utils.js"></script>
@@ -377,7 +378,14 @@
     </div>
 
     <script>
-        const API_ENDPOINT = 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+        const API_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
+            || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+        const DAO_FORMS_BASE = (window.Routes && window.Routes.gas && window.Routes.gas.daoForms)
+            || 'https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec';
+        const EDGAR_PING = (window.Routes && window.Routes.edgar && window.Routes.edgar.ping)
+            || 'https://edgar.truesight.me/ping';
+        const EDGAR_SUBMIT = (window.Routes && window.Routes.edgar && window.Routes.edgar.submit)
+            || 'https://edgar.truesight.me/dao/submit_contribution';
         const REPO_BASE_URL = 'https://github.com/TrueSightDAO/.github/tree/main/assets/';
         let resources = [];
         let allCurrencies = [];
@@ -458,7 +466,7 @@
         async function isOnline() {
             if (!navigator.onLine) return false;
             try {
-                const response = await fetch('https://edgar.truesight.me/ping', { method: 'HEAD', timeout: 5000 });
+                const response = await fetch(EDGAR_PING, { method: 'HEAD', timeout: 5000 });
                 return response.ok;
             } catch {
                 return false;
@@ -593,7 +601,7 @@
         async function loadMembers() {
             const memberInput = document.getElementById('memberInput');
             try {
-                const res = await fetch('https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec?list=true');
+                const res = await fetch(`${DAO_FORMS_BASE}?list=true`);
                 const members = await res.json();
                 allMembers = members || [];
                 const memberOptions = document.getElementById('memberOptions');
@@ -625,7 +633,7 @@
         async function loadLedgers() {
             const ledgerInput = document.getElementById('ledgerInput');
             try {
-                const res = await fetch('https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec?ledgers=true');
+                const res = await fetch(`${DAO_FORMS_BASE}?ledgers=true`);
                 const ledgers = await res.json();
                 allLedgers = ledgers || [];
                 const ledgerOptions = document.getElementById('ledgerOptions');
@@ -1022,7 +1030,7 @@
             }
             
             try {
-                const res = await fetch('https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec?manager=' + encodeURIComponent(memberKey));
+                const res = await fetch(`${DAO_FORMS_BASE}?manager=${encodeURIComponent(memberKey)}`);
                 resources = await res.json();
                 console.log('Loaded member resources:', resources.length, resources);
                 console.log('All currencies available:', allCurrencies.length, allCurrencies);
@@ -1146,7 +1154,7 @@
 
         async function loadAllCurrencies() {
             try {
-                const res = await fetch('https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec?all_currencies=true');
+                const res = await fetch(`${DAO_FORMS_BASE}?all_currencies=true`);
                 const data = await res.json();
                 if (data.status === 'success') {
                     allCurrencies = data.data.currencies || [];
@@ -1166,7 +1174,7 @@
             // This function is no longer used but kept for reference
             // The new onMemberChange() handles member selection
                 try {
-                    const res = await fetch('https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec?manager=' + encodeURIComponent(memberKey));
+                    const res = await fetch(`${DAO_FORMS_BASE}?manager=${encodeURIComponent(memberKey)}`);
                     resources = await res.json();
                     console.log('Loaded member resources:', resources.length, resources);
                     console.log('All currencies available:', allCurrencies.length, allCurrencies);
@@ -1502,7 +1510,7 @@
                     formData.append('text', shareText);
                     formData.append('attachment', file, fileName);
 
-                    const resp = await fetch("https://edgar.truesight.me/dao/submit_contribution", {
+                    const resp = await fetch(EDGAR_SUBMIT, {
                         method: 'POST',
                         body: formData
                     });

--- a/report_inventory_movement.html
+++ b/report_inventory_movement.html
@@ -14,6 +14,7 @@
     <meta property="og:type" content="website">
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
+    <script src="./routes.js"></script>
     <script src="./menu.js"></script>
     <script src="./tdg_balance.js"></script>
     
@@ -386,9 +387,18 @@
     <!-- Include jsQR library via CDN -->
     <script src="https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.min.js"></script>
     <script>
-        const API_ENDPOINT = 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
-        const QR_CODE_ENDPOINT = 'https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec?list=true';
-        const QR_CODE_LOOKUP_ENDPOINT = 'https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec';
+        const API_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
+            || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+        const QR_CODE_BASE = (window.Routes && window.Routes.gas && window.Routes.gas.qrCodes)
+            || 'https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec';
+        const QR_CODE_ENDPOINT = `${QR_CODE_BASE}?list=true`;
+        const QR_CODE_LOOKUP_ENDPOINT = QR_CODE_BASE;
+        const DAO_FORMS_BASE = (window.Routes && window.Routes.gas && window.Routes.gas.daoForms)
+            || 'https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec';
+        const EDGAR_PING = (window.Routes && window.Routes.edgar && window.Routes.edgar.ping)
+            || 'https://edgar.truesight.me/ping';
+        const EDGAR_SUBMIT = (window.Routes && window.Routes.edgar && window.Routes.edgar.submit)
+            || 'https://edgar.truesight.me/dao/submit_contribution';
         const REPO_BASE_URL = 'https://github.com/TrueSightDAO/.github/tree/main/assets/';
         // Register Service Worker for offline support
         if ('serviceWorker' in navigator) {
@@ -1506,7 +1516,7 @@
 
         async function loadManagers() {
             try {
-                const res = await fetch('https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec?list=true');
+                const res = await fetch(`${DAO_FORMS_BASE}?list=true`);
                 const managers = await res.json();
                 // Sort managers alphabetically by name
                 managersList = managers.sort((a, b) => a.name.localeCompare(b.name));
@@ -1620,7 +1630,7 @@
 
         async function loadRecipients() {
             try {
-                const res = await fetch('https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec?recipients=true');
+                const res = await fetch(`${DAO_FORMS_BASE}?recipients=true`);
                 const recs = await res.json();
                 recipientsList = recs;
                 
@@ -1766,7 +1776,7 @@
 
         async function loadAllCurrencies() {
             try {
-                const res = await fetch('https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec?all_currencies=true');
+                const res = await fetch(`${DAO_FORMS_BASE}?all_currencies=true`);
                 const data = await res.json();
                 if (data.status === 'success') {
                     // The listAllCurrenciesAcrossLedgers function returns currencies array
@@ -1982,7 +1992,7 @@
                 
                 try {
                     // Load manager assets
-                    const res = await fetch('https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec?manager=' + encodeURIComponent(managerKey));
+                    const res = await fetch(`${DAO_FORMS_BASE}?manager=${encodeURIComponent(managerKey)}`);
                     assets = await res.json();
                     console.log('Loaded manager assets:', assets.length, assets);
                     console.log('All currencies available:', allCurrencies.length, allCurrencies);
@@ -2231,7 +2241,7 @@
         async function isOnline() {
             if (!navigator.onLine) return false;
             try {
-                const response = await fetch('https://edgar.truesight.me/ping', { method: 'HEAD', timeout: 5000 });
+                const response = await fetch(EDGAR_PING, { method: 'HEAD', timeout: 5000 });
                 return response.ok;
             } catch {
                 return false;
@@ -2383,7 +2393,7 @@
                         formData.append('attachment', file, fileName);
                     }
 
-                    const resp = await fetch("https://edgar.truesight.me/dao/submit_contribution", {
+                    const resp = await fetch(EDGAR_SUBMIT, {
                         method: 'POST',
                         body: formData
                     });

--- a/report_sales.html
+++ b/report_sales.html
@@ -14,6 +14,7 @@
     <meta property="og:type" content="website">
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
+    <script src="./routes.js"></script>
     <script src="./menu.js"></script>
     <script src="./tdg_balance.js"></script>
     
@@ -395,9 +396,16 @@
                 .catch(err => console.warn('Service Worker registration failed:', err));
         }
 
-        const API_ENDPOINT = 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
-        const QR_CODE_ENDPOINT = 'https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec?list=true';
-        const QR_CODE_LOOKUP_ENDPOINT = 'https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec';
+        const API_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
+            || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+        const QR_CODE_BASE = (window.Routes && window.Routes.gas && window.Routes.gas.qrCodes)
+            || 'https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec';
+        const QR_CODE_ENDPOINT = `${QR_CODE_BASE}?list=true`;
+        const QR_CODE_LOOKUP_ENDPOINT = QR_CODE_BASE;
+        const EDGAR_PING = (window.Routes && window.Routes.edgar && window.Routes.edgar.ping)
+            || 'https://edgar.truesight.me/ping';
+        const EDGAR_SUBMIT = (window.Routes && window.Routes.edgar && window.Routes.edgar.submit)
+            || 'https://edgar.truesight.me/dao/submit_contribution';
         let contributorName = '';
         let qrCodes = [];
         let filteredQrCodes = [];
@@ -678,7 +686,7 @@
 
         async function loadContributors() {
             try {
-                const res = await fetch('https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec?list_with_members=true');
+                const res = await fetch(`${QR_CODE_BASE}?list_with_members=true`);
                 const data = await res.json();
                 if (data.status === 'error') {
                     throw new Error(data.message);
@@ -1060,7 +1068,7 @@
         async function isOnline() {
             if (!navigator.onLine) return false;
             try {
-                const response = await fetch('https://edgar.truesight.me/ping', { method: 'HEAD', timeout: 5000 });
+                const response = await fetch(EDGAR_PING, { method: 'HEAD', timeout: 5000 });
                 return response.ok;
             } catch {
                 return false;
@@ -1304,7 +1312,7 @@
                         formData.append('attachment', file, fileName);
                     }
 
-                    const resp = await fetch("https://edgar.truesight.me/dao/submit_contribution", {
+                    const resp = await fetch(EDGAR_SUBMIT, {
                         method: 'POST',
                         body: formData
                     });

--- a/routes.js
+++ b/routes.js
@@ -10,11 +10,14 @@
       submit: 'https://edgar.truesight.me/dao/submit_contribution',
     },
     gas: {
-      assetVerify: 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec',
-      qrCodes:     'https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec',
-      daoForms:    'https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec',
-      proposals:   'https://script.google.com/a/macros/agroverse.shop/s/AKfycbzgNstwRX1dWo17Dxny0t1ipJ6yLX02bTD_cKRuHr5RPJPemNVTj25mFhKo4UmR5Z7BIg/exec',
-      feedback:    'https://script.google.com/macros/s/AKfycbz3FQgXLaEc4KNq9fhCCFbf677OIcEMjVq_HjcgttMfCNWk7QWaCeTEq0xc5aRRbduFdg/exec',
+      assetVerify:      'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec',
+      qrCodes:          'https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec',
+      qrCodeGenerator:  'https://script.google.com/macros/s/AKfycbyGD0CDkvjo7K9O1gPnnqmdXvaJt9FM2v39HHqiDud5wwU6Mf41wwIOFS-NDD93xqoL/exec',
+      daoForms:         'https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec',
+      proposals:        'https://script.google.com/a/macros/agroverse.shop/s/AKfycbzgNstwRX1dWo17Dxny0t1ipJ6yLX02bTD_cKRuHr5RPJPemNVTj25mFhKo4UmR5Z7BIg/exec',
+      feedback:         'https://script.google.com/macros/s/AKfycbz3FQgXLaEc4KNq9fhCCFbf677OIcEMjVq_HjcgttMfCNWk7QWaCeTEq0xc5aRRbduFdg/exec',
+      stores:           'https://script.google.com/macros/s/AKfycbwB2zqNV9nMCMWs2hSa8FecjA36Oh-mSVuz3pk8TpXrXcy9dvqOqgbWIirNka2LmacgPw/exec',
+      shipping:         'https://script.google.com/macros/s/AKfycbz5Tt_vz1X26i82yqlGUSI_OtCUEO31jImZH2tXfNaxMbfmJ01dkwUIEZDjsnd10xMbcg/exec',
     },
   };
 })(typeof self !== 'undefined' ? self : this);

--- a/scanner.html
+++ b/scanner.html
@@ -14,6 +14,7 @@
     <meta property="og:type" content="website">
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
+    <script src="./routes.js"></script>
     <script src="./menu.js"></script>
     <script src="./tdg_balance.js"></script>
     
@@ -249,7 +250,12 @@
                 .catch(err => console.warn('Service Worker registration failed:', err));
         }
 
-        const API_ENDPOINT = 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+        const API_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
+            || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+        const EDGAR_PING = (window.Routes && window.Routes.edgar && window.Routes.edgar.ping)
+            || 'https://edgar.truesight.me/ping';
+        const EDGAR_SUBMIT = (window.Routes && window.Routes.edgar && window.Routes.edgar.submit)
+            || 'https://edgar.truesight.me/dao/submit_contribution';
         let contributorName = '';
         let scanning = false;
         let lastQrParam = null;
@@ -286,7 +292,7 @@
         async function isOnline() {
             if (!navigator.onLine) return false;
             try {
-                const response = await fetch('https://edgar.truesight.me/ping', { method: 'HEAD', timeout: 5000 });
+                const response = await fetch(EDGAR_PING, { method: 'HEAD', timeout: 5000 });
                 return response.ok;
             } catch {
                 return false;
@@ -505,7 +511,7 @@
                         formData.append('attachment', file, fileName);
                     }
 
-                    const resp = await fetch("https://edgar.truesight.me/dao/submit_contribution", {
+                    const resp = await fetch(EDGAR_SUBMIT, {
                         method: 'POST',
                         body: formData
                     });

--- a/shipping_planner.html
+++ b/shipping_planner.html
@@ -52,6 +52,7 @@
         };
     </script>
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCS5tz9sp9mWG6d_glVO19UUk8ZyZ3LdbQ&callback=onGoogleMapsReady&v=weekly&loading=async&libraries=places"></script>
+    <script src="./routes.js"></script>
     <script src="./menu.js"></script>
     <script src="./tdg_balance.js"></script>
     
@@ -582,7 +583,8 @@
     
     <script>
         // Configuration - Google Apps Script deployment URL
-        const API_BASE_URL = 'https://script.google.com/macros/s/AKfycbz5Tt_vz1X26i82yqlGUSI_OtCUEO31jImZH2tXfNaxMbfmJ01dkwUIEZDjsnd10xMbcg/exec';
+        const API_BASE_URL = (window.Routes && window.Routes.gas && window.Routes.gas.shipping)
+            || 'https://script.google.com/macros/s/AKfycbz5Tt_vz1X26i82yqlGUSI_OtCUEO31jImZH2tXfNaxMbfmJ01dkwUIEZDjsnd10xMbcg/exec';
         // Freight lane registry (TrueSightDAO/agroverse-freight-audit)
         const FREIGHT_LANES_INDEX_URL = 'https://raw.githubusercontent.com/TrueSightDAO/agroverse-freight-audit/main/pointers/freight_lanes.json';
         

--- a/stores_nearby.html
+++ b/stores_nearby.html
@@ -44,6 +44,7 @@
         };
     </script>
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBWmnvjWeYIEju0JLbfN-Z09k1HEsXzWe4&callback=onGoogleMapsReady&v=weekly&loading=async&libraries=places"></script>
+    <script src="./routes.js"></script>
     <script src="./menu.js"></script>
     <script src="./tdg_balance.js"></script>
     
@@ -1437,8 +1438,10 @@
 
     <script>
         // Google Apps Script deployment URLs
-        const API_URL = 'https://script.google.com/macros/s/AKfycbwB2zqNV9nMCMWs2hSa8FecjA36Oh-mSVuz3pk8TpXrXcy9dvqOqgbWIirNka2LmacgPw/exec';                   
-        const SIGNATURE_VERIFY_API = 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';        
+        const API_URL = (window.Routes && window.Routes.gas && window.Routes.gas.stores)
+            || 'https://script.google.com/macros/s/AKfycbwB2zqNV9nMCMWs2hSa8FecjA36Oh-mSVuz3pk8TpXrXcy9dvqOqgbWIirNka2LmacgPw/exec';
+        const SIGNATURE_VERIFY_API = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
+            || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';        
 
         const stateNameLookup = {
             'alabama': 'AL', 'alaska': 'AK', 'arizona': 'AZ', 'arkansas': 'AR',

--- a/update_qr_code.html
+++ b/update_qr_code.html
@@ -15,6 +15,7 @@
     
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
+    <script src="./routes.js"></script>
     <script src="./menu.js"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/edgar_payload_helper.js"></script>
@@ -381,11 +382,15 @@
     </div>
 
     <script>
-        const API_ENDPOINT = 'https://edgar.truesight.me/dao/submit_contribution';
-        const VERIFY_ENDPOINT = 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
-        const MEMBERS_ENDPOINT = 'https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec?list_with_members=true';
-        const QR_CODE_ENDPOINT = 'https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec?list_all=true';
-        const LOOKUP_ENDPOINT = 'https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec';
+        const API_ENDPOINT = (window.Routes && window.Routes.edgar && window.Routes.edgar.submit)
+            || 'https://edgar.truesight.me/dao/submit_contribution';
+        const VERIFY_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
+            || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+        const QR_CODE_BASE = (window.Routes && window.Routes.gas && window.Routes.gas.qrCodes)
+            || 'https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec';
+        const MEMBERS_ENDPOINT = `${QR_CODE_BASE}?list_with_members=true`;
+        const QR_CODE_ENDPOINT = `${QR_CODE_BASE}?list_all=true`;
+        const LOOKUP_ENDPOINT = QR_CODE_BASE;
 
         let qrCodes = [];
         let filteredQrCodes = [];


### PR DESCRIPTION
## Summary
Migrates 8 pages in the Inventory & Sales module to `Routes`, with hardcoded fallbacks preserved. Adds three new GAS keys to `routes.js` required by this module:

- `Routes.gas.qrCodeGenerator` — batch QR generation GAS (used by `batch_qr_generator.html`)
- `Routes.gas.stores` — holistic-wellness stores directory (used by `stores_nearby.html`)
- `Routes.gas.shipping` — freight estimation GAS (used by `shipping_planner.html`)

| Page | Routes keys wired |
|------|-------------------|
| `scanner.html` | `assetVerify`, `edgar.ping`, `edgar.submit` |
| `report_sales.html` | `assetVerify`, `qrCodes` (base), `edgar.ping`, `edgar.submit` |
| `report_dao_expenses.html` | `assetVerify`, `daoForms` (base for list/ledgers/manager/all_currencies), `edgar.ping`, `edgar.submit` |
| `report_inventory_movement.html` | `assetVerify`, `daoForms`, `qrCodes`, `edgar.ping`, `edgar.submit` |
| `update_qr_code.html` | `edgar.submit`, `assetVerify`, `qrCodes` (MEMBERS/QR_CODE/LOOKUP derived) |
| `batch_qr_generator.html` | `assetVerify`, `qrCodeGenerator`, `edgar.submit` |
| `stores_nearby.html` | `stores`, `assetVerify` |
| `shipping_planner.html` | `shipping` |

Where URLs included a query string (e.g. `?list=true`), the migration derives a `*_BASE` constant from Routes and uses template strings so the query contract is unchanged.

## Test plan
- [ ] Smoke test each page end-to-end — signature verification, list loads (QR codes, ledgers, recipients, currencies, members), Edgar ping, and submit where applicable
- [ ] `report_sales.html`: scan a QR, complete a test sale
- [ ] `report_dao_expenses.html`: select a member, confirm `?manager=` lookup returns ledger options
- [ ] `batch_qr_generator.html`: confirm batch generation hits the correct GAS deployment
- [ ] `stores_nearby.html`: confirm the stores list loads
- [ ] `shipping_planner.html`: confirm freight lanes load

🤖 Generated with [Claude Code](https://claude.com/claude-code)