### PR TITLE
feat(routes): migrate remaining pages + tdg_balance.js (completes dapp sweep)

### DIFF
--- a/repackaging_planner.html
+++ b/repackaging_planner.html
@@ -10,6 +10,7 @@
   <meta property="og:url" content="https://truesightdao.github.io/dapp/repackaging_planner.html">
   <meta property="og:type" content="website">
   <link rel="icon" type="image/png" href="https://raw.githubusercontent.com/TrueSightDAO/.github/main/assets/20240612_truesight_dao_logo_square.png">
+  <script src="./routes.js"></script>
   <script src="./menu.js"></script>
   <script src="./tdg_balance.js"></script>
   <title>Repackaging Planner - TrueSight DAO</title>
@@ -220,9 +221,12 @@
 
   <script>
 (function () {
-  var INVENTORY_API = 'https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec';
-  var SIGNATURE_API = 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
-  var EDGAR_SUBMIT_URL = 'https://edgar.truesight.me/dao/submit_contribution';
+  var INVENTORY_API = (window.Routes && window.Routes.gas && window.Routes.gas.daoForms)
+      || 'https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec';
+  var SIGNATURE_API = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
+      || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+  var EDGAR_SUBMIT_URL = (window.Routes && window.Routes.edgar && window.Routes.edgar.submit)
+      || 'https://edgar.truesight.me/dao/submit_contribution';
   var COMPOSITION_RAW_BASE = 'https://raw.githubusercontent.com/TrueSightDAO/agroverse-inventory/main/currency-compositions/';
   var PROOF_MAX_BYTES = 500000;
 

--- a/report_capital_injection.html
+++ b/report_capital_injection.html
@@ -15,6 +15,7 @@
     
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
+    <script src="./routes.js"></script>
     <script src="./menu.js"></script>
     <script src="./tdg_balance.js"></script>
 
@@ -324,6 +325,10 @@
 
     <script>
         const REPO_BASE_URL = 'https://github.com/TrueSightDAO/.github/tree/main/assets/';
+        const DAO_FORMS_BASE = (window.Routes && window.Routes.gas && window.Routes.gas.daoForms)
+            || 'https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec';
+        const EDGAR_SUBMIT = (window.Routes && window.Routes.edgar && window.Routes.edgar.submit)
+            || 'https://edgar.truesight.me/dao/submit_contribution';
         let file = null;
         let fileName = '';
         let contributionLocation = '';
@@ -370,7 +375,7 @@
         async function loadLedgers() {
             const ledgerSelect = document.getElementById('ledgerSelect');
             try {
-                const response = await fetch('https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec?ledgers=true');
+                const response = await fetch(`${DAO_FORMS_BASE}?ledgers=true`);
                 const ledgers = await response.json();
                 
                 ledgerSelect.innerHTML = '<option value="">Select a ledger</option>';
@@ -627,7 +632,7 @@
                         formData.append('attachment', file, fileName);
                     }
 
-                    const resp = await fetch('https://edgar.truesight.me/dao/submit_contribution', {
+                    const resp = await fetch(EDGAR_SUBMIT, {
                         method: 'POST',
                         body: formData
                     });

--- a/restock_recommender.html
+++ b/restock_recommender.html
@@ -23,6 +23,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
+    <script src="./routes.js"></script>
     <script src="./menu.js"></script>
     <script src="./tdg_balance.js"></script>
     <style>
@@ -140,7 +141,8 @@
 
     <script>
         (function() {
-            const API_BASE_URL = 'https://script.google.com/macros/s/AKfycbz5Tt_vz1X26i82yqlGUSI_OtCUEO31jImZH2tXfNaxMbfmJ01dkwUIEZDjsnd10xMbcg/exec';
+            const API_BASE_URL = (window.Routes && window.Routes.gas && window.Routes.gas.shipping)
+                || 'https://script.google.com/macros/s/AKfycbz5Tt_vz1X26i82yqlGUSI_OtCUEO31jImZH2tXfNaxMbfmJ01dkwUIEZDjsnd10xMbcg/exec';
             const partnerSelect = document.getElementById('partnerSelect');
             const productSelect = document.getElementById('productSelect');
             const getBtn = document.getElementById('getBtn');

--- a/routes.js
+++ b/routes.js
@@ -17,6 +17,7 @@
       proposals:        'https://script.google.com/a/macros/agroverse.shop/s/AKfycbzgNstwRX1dWo17Dxny0t1ipJ6yLX02bTD_cKRuHr5RPJPemNVTj25mFhKo4UmR5Z7BIg/exec',
       feedback:         'https://script.google.com/macros/s/AKfycbz3FQgXLaEc4KNq9fhCCFbf677OIcEMjVq_HjcgttMfCNWk7QWaCeTEq0xc5aRRbduFdg/exec',
       stores:           'https://script.google.com/macros/s/AKfycbwB2zqNV9nMCMWs2hSa8FecjA36Oh-mSVuz3pk8TpXrXcy9dvqOqgbWIirNka2LmacgPw/exec',
+      storesHitList:    'https://script.google.com/macros/s/AKfycbwoBqZnDS4JRRdFkxSXdlGt-qIn-RauMcORuDHeWs29oQ2CpJ3L4A10uM8se9anL108/exec',
       shipping:         'https://script.google.com/macros/s/AKfycbz5Tt_vz1X26i82yqlGUSI_OtCUEO31jImZH2tXfNaxMbfmJ01dkwUIEZDjsnd10xMbcg/exec',
     },
   };

--- a/store_interaction_history.html
+++ b/store_interaction_history.html
@@ -19,6 +19,7 @@
     <meta name="twitter:image" content="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
+    <script src="./routes.js"></script>
     <script src="./menu.js"></script>
     <script src="./tdg_balance.js"></script>
 
@@ -487,17 +488,20 @@
     <script>
 (function () {
     /** Read-only history API (holistic_hit_list_store_history). */
-    var API_BASE_URL = 'https://script.google.com/macros/s/AKfycbwoBqZnDS4JRRdFkxSXdlGt-qIn-RauMcORuDHeWs29oQ2CpJ3L4A10uM8se9anL108/exec';
+    var API_BASE_URL = (window.Routes && window.Routes.gas && window.Routes.gas.storesHitList)
+        || 'https://script.google.com/macros/s/AKfycbwoBqZnDS4JRRdFkxSXdlGt-qIn-RauMcORuDHeWs29oQ2CpJ3L4A10uM8se9anL108/exec';
     var API_TOKEN = '';
 
     /**
      * Hit List read/write API — must match stores_nearby.html API_URL
      * (action=update_status, shop_name, new_status, …).
      */
-    var STORES_NEARBY_API_URL = 'https://script.google.com/macros/s/AKfycbwB2zqNV9nMCMWs2hSa8FecjA36Oh-mSVuz3pk8TpXrXcy9dvqOqgbWIirNka2LmacgPw/exec';
+    var STORES_NEARBY_API_URL = (window.Routes && window.Routes.gas && window.Routes.gas.stores)
+        || 'https://script.google.com/macros/s/AKfycbwB2zqNV9nMCMWs2hSa8FecjA36Oh-mSVuz3pk8TpXrXcy9dvqOqgbWIirNka2LmacgPw/exec';
 
     /** Same as stores_nearby.html SIGNATURE_VERIFY_API */
-    var SIGNATURE_VERIFY_API = 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+    var SIGNATURE_VERIFY_API = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
+        || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
 
     var searchInput = document.getElementById('storeSearch');
     var suggestPanel = document.getElementById('suggestPanel');

--- a/stores_by_status.html
+++ b/stores_by_status.html
@@ -14,6 +14,7 @@
     <meta property="og:site_name" content="TrueSight DAO">
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
+    <script src="./routes.js"></script>
     <script src="./menu.js"></script>
     <script src="./tdg_balance.js"></script>
 
@@ -324,7 +325,8 @@
 
     <script>
 (function () {
-    var API_BASE_URL = 'https://script.google.com/macros/s/AKfycbwoBqZnDS4JRRdFkxSXdlGt-qIn-RauMcORuDHeWs29oQ2CpJ3L4A10uM8se9anL108/exec';
+    var API_BASE_URL = (window.Routes && window.Routes.gas && window.Routes.gas.storesHitList)
+        || 'https://script.google.com/macros/s/AKfycbwoBqZnDS4JRRdFkxSXdlGt-qIn-RauMcORuDHeWs29oQ2CpJ3L4A10uM8se9anL108/exec';
     var API_TOKEN = '';
 
     var STATUS_OPTIONS = [

--- a/tdg_balance.js
+++ b/tdg_balance.js
@@ -9,7 +9,8 @@
  * See DAPP_PAGE_CONVENTIONS.md and UX_CONVENTIONS.md.
  */
 (function() {
-  const API_ENDPOINT = 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+  const API_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
+      || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
 
   function formatRights(n) {
     if (n >= 1000000) return n.toLocaleString('en-US', { maximumFractionDigits: 0 });


### PR DESCRIPTION
## Summary
Completes the routes.js sweep across the DApp. Adds one new GAS key:

- `Routes.gas.storesHitList` — stores-by-status / interaction-history GAS

Migrated files:

| File | Routes keys wired |
|------|-------------------|
| `repackaging_planner.html` | `daoForms`, `assetVerify`, `edgar.submit` |
| `stores_by_status.html` | `storesHitList` |
| `report_capital_injection.html` | `daoForms`, `edgar.submit` |
| `restock_recommender.html` | `shipping` |
| `store_interaction_history.html` | `storesHitList`, `stores`, `assetVerify` |
| `tdg_balance.js` (shared, loaded by every page) | `assetVerify` |

After this PR, no HTML or JS file in `dapp/` has an unguarded endpoint literal. Only `routes.js` and the service-worker origin matcher reference URL strings directly. Hardcoded fallbacks remain everywhere as a safety net — they can be removed in a separate follow-up once this has baked in production for a release.

## Test plan
- [ ] Load every previously-migrated page and confirm no `window.Routes` undefined errors
- [ ] `repackaging_planner.html`: confirm holder inventory loads, signature verification succeeds, submit works
- [ ] `stores_by_status.html`: confirm status filter + store list load
- [ ] `report_capital_injection.html`: confirm ledgers dropdown populates, submit works
- [ ] `restock_recommender.html`: confirm shipping estimates render
- [ ] `store_interaction_history.html`: confirm store lookup + interaction history load
- [ ] `tdg_balance.js`: confirm TDG balance badge still renders on every page

🤖 Generated with [Claude Code](https://claude.com/claude-code)