### PR TITLE
feat(routes): probe-and-flip fallback to Edgar proxy for GFW-blocked users

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -3,22 +3,106 @@
   // Works in both window (pages) and self (service worker via importScripts).
   // Schemas live in tokenomics/API_ENDPOINTS.md — keep that doc in sync when
   // adding or changing any URL here.
+  //
+  // Two modes for Routes.gas.*:
+  //   direct — call script.google.com directly (default, works everywhere except GFW)
+  //   proxy  — route via edgar.truesight.me/proxy/gas/<name>, for networks
+  //            that block script.google.com (server-side implementation lives
+  //            in sentiment_importer/app/controllers/proxy_controller.rb; its
+  //            GAS_UPSTREAMS keys MUST stay in lockstep with directGas below)
+  //
+  // Mode selection at parse time (in this order):
+  //   1. ?route=direct / ?route=proxy URL param (wins; persisted to localStorage)
+  //   2. localStorage.routesMode (set by prior probe or prior URL override)
+  //   3. default: direct
+  //
+  // An async probe fires once per session on direct mode. If script.google.com
+  // is unreachable within 3 seconds, the probe flips localStorage to 'proxy'
+  // and reloads the page so subsequent URL captures see proxy URLs.
+
+  var PROXY_BASE = 'https://edgar.truesight.me/proxy/gas/';
+
+  var directGas = {
+    assetVerify:      'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec',
+    qrCodes:          'https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec',
+    qrCodeGenerator:  'https://script.google.com/macros/s/AKfycbyGD0CDkvjo7K9O1gPnnqmdXvaJt9FM2v39HHqiDud5wwU6Mf41wwIOFS-NDD93xqoL/exec',
+    daoForms:         'https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec',
+    proposals:        'https://script.google.com/a/macros/agroverse.shop/s/AKfycbzgNstwRX1dWo17Dxny0t1ipJ6yLX02bTD_cKRuHr5RPJPemNVTj25mFhKo4UmR5Z7BIg/exec',
+    feedback:         'https://script.google.com/macros/s/AKfycbz3FQgXLaEc4KNq9fhCCFbf677OIcEMjVq_HjcgttMfCNWk7QWaCeTEq0xc5aRRbduFdg/exec',
+    stores:           'https://script.google.com/macros/s/AKfycbwB2zqNV9nMCMWs2hSa8FecjA36Oh-mSVuz3pk8TpXrXcy9dvqOqgbWIirNka2LmacgPw/exec',
+    storesHitList:    'https://script.google.com/macros/s/AKfycbwoBqZnDS4JRRdFkxSXdlGt-qIn-RauMcORuDHeWs29oQ2CpJ3L4A10uM8se9anL108/exec',
+    shipping:         'https://script.google.com/macros/s/AKfycbz5Tt_vz1X26i82yqlGUSI_OtCUEO31jImZH2tXfNaxMbfmJ01dkwUIEZDjsnd10xMbcg/exec'
+  };
+
+  var proxyGas = {};
+  for (var key in directGas) {
+    if (Object.prototype.hasOwnProperty.call(directGas, key)) {
+      proxyGas[key] = PROXY_BASE + key;
+    }
+  }
+
+  var isWindow = typeof window !== 'undefined';
+  var mode = 'direct';
+
+  if (isWindow) {
+    try {
+      var params = new URLSearchParams(window.location.search);
+      var override = params.get('route');
+      if (override === 'direct' || override === 'proxy') {
+        mode = override;
+        localStorage.setItem('routesMode', mode);
+      } else {
+        mode = localStorage.getItem('routesMode') || 'direct';
+      }
+    } catch (_) {
+      mode = 'direct';
+    }
+  }
+
   global.Routes = {
     edgar: {
       base:   'https://edgar.truesight.me',
       ping:   'https://edgar.truesight.me/ping',
-      submit: 'https://edgar.truesight.me/dao/submit_contribution',
+      submit: 'https://edgar.truesight.me/dao/submit_contribution'
     },
-    gas: {
-      assetVerify:      'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec',
-      qrCodes:          'https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec',
-      qrCodeGenerator:  'https://script.google.com/macros/s/AKfycbyGD0CDkvjo7K9O1gPnnqmdXvaJt9FM2v39HHqiDud5wwU6Mf41wwIOFS-NDD93xqoL/exec',
-      daoForms:         'https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec',
-      proposals:        'https://script.google.com/a/macros/agroverse.shop/s/AKfycbzgNstwRX1dWo17Dxny0t1ipJ6yLX02bTD_cKRuHr5RPJPemNVTj25mFhKo4UmR5Z7BIg/exec',
-      feedback:         'https://script.google.com/macros/s/AKfycbz3FQgXLaEc4KNq9fhCCFbf677OIcEMjVq_HjcgttMfCNWk7QWaCeTEq0xc5aRRbduFdg/exec',
-      stores:           'https://script.google.com/macros/s/AKfycbwB2zqNV9nMCMWs2hSa8FecjA36Oh-mSVuz3pk8TpXrXcy9dvqOqgbWIirNka2LmacgPw/exec',
-      storesHitList:    'https://script.google.com/macros/s/AKfycbwoBqZnDS4JRRdFkxSXdlGt-qIn-RauMcORuDHeWs29oQ2CpJ3L4A10uM8se9anL108/exec',
-      shipping:         'https://script.google.com/macros/s/AKfycbz5Tt_vz1X26i82yqlGUSI_OtCUEO31jImZH2tXfNaxMbfmJ01dkwUIEZDjsnd10xMbcg/exec',
-    },
+    gas: mode === 'proxy' ? proxyGas : directGas,
+    mode: mode,
+    proxyBase: PROXY_BASE
   };
+
+  // Async probe: only in window, only on direct mode, once per session.
+  // Uses sessionStorage to guard against a reload loop if the probe itself
+  // triggers a reload. On failure, flip localStorage to 'proxy' and reload.
+  if (isWindow && mode === 'direct') {
+    try {
+      if (sessionStorage.getItem('routesProbed') !== 'true') {
+        sessionStorage.setItem('routesProbed', 'true');
+
+        var controller = new AbortController();
+        var timeoutId = setTimeout(function () { controller.abort(); }, 3000);
+
+        fetch(directGas.assetVerify, {
+          method: 'GET',
+          mode: 'no-cors',
+          cache: 'no-store',
+          signal: controller.signal
+        }).then(function () {
+          clearTimeout(timeoutId);
+        }).catch(function () {
+          clearTimeout(timeoutId);
+          try {
+            localStorage.setItem('routesMode', 'proxy');
+            if (typeof console !== 'undefined' && console.warn) {
+              console.warn('[routes.js] script.google.com unreachable; switching to Edgar proxy and reloading.');
+            }
+            window.location.reload();
+          } catch (_) {
+            // localStorage unavailable — nothing to do.
+          }
+        });
+      }
+    } catch (_) {
+      // sessionStorage unavailable — skip probe.
+    }
+  }
 })(typeof self !== 'undefined' ? self : this);


### PR DESCRIPTION
## Summary
Adds GFW-resilience to `routes.js`. When `script.google.com` is unreachable (typically from behind the GFW), the DApp auto-detects this on first page load and flips every `Routes.gas.*` URL to route through `edgar.truesight.me/proxy/gas/<name>` instead. Subsequent page loads use the proxy transparently.

**How the three pieces work together:**
1. Pages load `routes.js` synchronously → `Routes.gas.*` is populated at parse time from either direct URLs or proxy URLs based on `localStorage.routesMode`.
2. On first page load in a session, an async probe fires a 3s-timeout no-cors GET to the assetVerify GAS URL. If it fails (abort/network error), `localStorage.routesMode` is flipped to `'proxy'` and the page is reloaded.
3. On reload, `routes.js` sees `mode='proxy'` and sets `Routes.gas.*` to `edgar.truesight.me/proxy/gas/<name>` URLs. The server-side allowlist (shipped in sentiment_importer #1025) forwards these to the real GAS URLs and returns byte-identical responses.

**Mode precedence:** `?route=direct` / `?route=proxy` URL param > `localStorage.routesMode` > default `direct`. URL param persists to localStorage.

**Guards against reload loops:** `sessionStorage.routesProbed='true'` is set *before* the probe fires; combined with the `mode === 'direct'` check, a second probe cannot fire within the same session.

**Service worker is unaffected** — no `window`/`localStorage` there, so the SW pre-cache still hits direct URLs. For GFW users the SW install will fail silently on those two pre-cache URLs; fetch-handler remains fully functional via the proxy. Tightening SW install for blocked users is a separate follow-up.

## Recovery / override
- Force proxy mode: append `?route=proxy` to any page URL.
- Force direct mode: append `?route=direct`.
- Manual reset: `localStorage.removeItem('routesMode'); sessionStorage.removeItem('routesProbed'); location.reload();`

## Test plan
- [ ] **Default path (non-China):** load any page; `window.Routes.mode` === `'direct'`, `Routes.gas.assetVerify` starts with `https://script.google.com/...`, probe succeeds silently (no reload).
- [ ] **Forced proxy:** load `?route=proxy`, confirm `Routes.gas.assetVerify === 'https://edgar.truesight.me/proxy/gas/assetVerify'`, and submit-feedback / review-proposal still work end-to-end (proves the Edgar proxy round-trips correctly).
- [ ] **Simulated GFW:** in DevTools → Network → add `script.google.com` to request-blocking, reload. Confirm the probe catches the failure, flips `localStorage.routesMode` to `'proxy'`, and reloads into proxy mode automatically.
- [ ] **Reload loop guard:** after the auto-reload, confirm no further reloads happen (`sessionStorage.routesProbed` remains `true`).
- [ ] **Reset:** run the manual reset snippet above; confirm probe runs again on next load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)