### PR TITLE
feat(report-inventory-movement): read managers + items from treasury-cache JSON

### DIFF
--- a/report_inventory_movement.html
+++ b/report_inventory_movement.html
@@ -1512,24 +1512,124 @@
         }
 
 
+        // --- Treasury cache (pre-computed inventory snapshot) ---
+        //
+        // Reads the nightly-ish snapshot committed to
+        // github.com/TrueSightDAO/treasury-cache/main (refreshed on every
+        // [INVENTORY MOVEMENT] batch + 30-min safety-net cron) so the three
+        // slow GAS fetches below can be skipped. If the fetch fails or the
+        // JSON is malformed, every consumer falls back to the existing GAS.
+        //
+        // Schema: https://github.com/TrueSightDAO/treasury-cache/blob/main/README.md
+        const TREASURY_CACHE_BASE_URL = 'https://raw.githubusercontent.com/TrueSightDAO/treasury-cache/main/dao_offchain_treasury.json';
+        const TREASURY_CACHE_SESSION_BUST = Date.now(); // freshen per page load, memoize within session
+        let _treasuryCachePromise = null;
+
+        async function getTreasuryCache() {
+            if (_treasuryCachePromise) return _treasuryCachePromise;
+            _treasuryCachePromise = (async () => {
+                try {
+                    const url = `${TREASURY_CACHE_BASE_URL}?t=${TREASURY_CACHE_SESSION_BUST}`;
+                    const res = await fetch(url, { cache: 'no-store' });
+                    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                    const json = await res.json();
+                    if (!json || !Array.isArray(json.items) || !Array.isArray(json.managers)) {
+                        throw new Error('malformed treasury-cache JSON');
+                    }
+                    console.log('[treasury-cache] loaded', {
+                        generated_at: json.generated_at,
+                        trigger: json.trigger,
+                        item_types: json.totals && json.totals.item_types,
+                        managers: json.totals && json.totals.managers_count
+                    });
+                    return json;
+                } catch (err) {
+                    console.warn('[treasury-cache] load failed, will fall back to GAS:', err);
+                    return null;
+                }
+            })();
+            return _treasuryCachePromise;
+        }
+
+        async function getManagersFromTreasuryCache() {
+            const snap = await getTreasuryCache();
+            if (!snap) return null;
+            return snap.managers.map(m => ({ key: m.manager_key, name: m.manager_name }));
+        }
+
+        async function getAllCurrenciesFromTreasuryCache() {
+            const snap = await getTreasuryCache();
+            if (!snap) return null;
+            // Translate treasury-cache items[] to the ?all_currencies=true shape the
+            // DApp already knows how to render. "Main Ledger" is excluded from
+            // ledger_quantities to match the GAS response exactly (it only exposes
+            // external AGL ledgers there).
+            return snap.items.map(it => {
+                const ledgerQuantities = {};
+                Object.entries(it.ledgers || {}).forEach(([name, qty]) => {
+                    if (name !== 'Main Ledger') ledgerQuantities[name] = qty;
+                });
+                return {
+                    product_name: it.currency,
+                    product_image: '',
+                    landing_page: '',
+                    ledger: '',
+                    farm_name: '',
+                    state: '',
+                    country: '',
+                    year: '',
+                    unit_weight_g: it.unit_weight_g != null ? it.unit_weight_g : null,
+                    total_quantity: it.total_quantity,
+                    ledger_quantities: ledgerQuantities
+                };
+            });
+        }
+
+        async function getManagerAssetsFromTreasuryCache(managerKey) {
+            const snap = await getTreasuryCache();
+            if (!snap) return null;
+            const manager = snap.managers.find(m => m.manager_key === managerKey);
+            if (!manager) return []; // known manager-set, just has no assets
+            return manager.items.map(itm => {
+                const out = { currency: itm.currency, amount: itm.amount };
+                if (itm.unit_cost_usd != null) out.unit_cost = itm.unit_cost_usd;
+                if (itm.total_value_usd != null) out.total_value = itm.total_value_usd;
+                if (itm.ledger) out.ledger = itm.ledger;
+                return out;
+            });
+        }
+        // --- end treasury cache ---
+
         let managersList = [];
 
         async function loadManagers() {
+            let managers = null;
+            let source = 'treasury-cache';
             try {
-                const res = await fetch(`${DAO_FORMS_BASE}?list=true`);
-                const managers = await res.json();
-                // Sort managers alphabetically by name
-                managersList = managers.sort((a, b) => a.name.localeCompare(b.name));
-                
-                const display = document.getElementById('managerSelectDisplay');
-                if (display) {
-                    display.textContent = 'Select a manager';
-                    display.style.color = '#999';
-                }
+                managers = await getManagersFromTreasuryCache();
             } catch (err) {
-                console.error('Error loading managers:', err);
-                document.getElementById('reportOutput').textContent = 'Failed to load managers: ' + err.message;
-                document.getElementById('reportOutput').className = 'error';
+                console.warn('[treasury-cache] getManagersFromTreasuryCache failed:', err);
+            }
+            if (!managers) {
+                source = 'gas';
+                try {
+                    const res = await fetch(`${DAO_FORMS_BASE}?list=true`);
+                    managers = await res.json();
+                } catch (err) {
+                    console.error('Error loading managers:', err);
+                    document.getElementById('reportOutput').textContent = 'Failed to load managers: ' + err.message;
+                    document.getElementById('reportOutput').className = 'error';
+                    return;
+                }
+            }
+            // Sort managers alphabetically by name
+            managersList = managers.sort((a, b) => a.name.localeCompare(b.name));
+            console.log(`[managers] loaded ${managersList.length} via ${source}`);
+
+            const display = document.getElementById('managerSelectDisplay');
+            if (display) {
+                display.textContent = 'Select a manager';
+                display.style.color = '#999';
             }
         }
         
@@ -1775,20 +1875,25 @@
         }
 
         async function loadAllCurrencies() {
+            // Prefer the pre-computed treasury-cache; fall back to the GAS
+            // ?all_currencies=true endpoint on any failure.
+            try {
+                const cached = await getAllCurrenciesFromTreasuryCache();
+                if (cached) {
+                    allCurrencies = cached;
+                    console.log(`[all_currencies] loaded ${allCurrencies.length} via treasury-cache`);
+                    return;
+                }
+            } catch (err) {
+                console.warn('[treasury-cache] getAllCurrenciesFromTreasuryCache failed:', err);
+            }
             try {
                 const res = await fetch(`${DAO_FORMS_BASE}?all_currencies=true`);
                 const data = await res.json();
                 if (data.status === 'success') {
                     // The listAllCurrenciesAcrossLedgers function returns currencies array
                     allCurrencies = data.data.currencies || [];
-                    console.log('Loaded all currencies across ledgers:', allCurrencies.length, allCurrencies);
-                    if (allCurrencies.length > 0) {
-                        console.log('First currency type:', typeof allCurrencies[0]);
-                        console.log('First currency object:', allCurrencies[0]);
-                        console.log('Product name:', allCurrencies[0].product_name);
-                        console.log('Ledger URL:', allCurrencies[0].ledger);
-                        console.log('Ledger quantities:', allCurrencies[0].ledger_quantities);
-                    }
+                    console.log(`[all_currencies] loaded ${allCurrencies.length} via gas`);
                 } else {
                     console.error('Error from listAllCurrenciesAcrossLedgers:', data.message);
                     allCurrencies = [];
@@ -1991,15 +2096,25 @@
                 showItemSelectLoading();
                 
                 try {
-                    // Load manager assets
-                    const res = await fetch(`${DAO_FORMS_BASE}?manager=${encodeURIComponent(managerKey)}`);
-                    assets = await res.json();
-                    console.log('Loaded manager assets:', assets.length, assets);
-                    console.log('All currencies available:', allCurrencies.length, allCurrencies);
-                    
+                    // Load manager assets — prefer treasury-cache; fall back to GAS on miss
+                    let cachedAssets = null;
+                    try {
+                        cachedAssets = await getManagerAssetsFromTreasuryCache(managerKey);
+                    } catch (cacheErr) {
+                        console.warn('[treasury-cache] getManagerAssetsFromTreasuryCache failed:', cacheErr);
+                    }
+                    if (cachedAssets) {
+                        assets = cachedAssets;
+                        console.log(`[manager_assets] loaded ${assets.length} via treasury-cache`);
+                    } else {
+                        const res = await fetch(`${DAO_FORMS_BASE}?manager=${encodeURIComponent(managerKey)}`);
+                        assets = await res.json();
+                        console.log(`[manager_assets] loaded ${assets.length} via gas`);
+                    }
+
                     // Clear loading state
                     clearItemSelectLoading();
-                    
+
                     // Populate item select with cached data
                     populateItemSelectFromManagerAssets();
                 } catch (err) {


### PR DESCRIPTION
## Summary

- `report_inventory_movement.html` now reads the Warehouse Manager + Inventory Item dropdowns from the pre-computed [treasury-cache JSON](https://raw.githubusercontent.com/TrueSightDAO/treasury-cache/main/dao_offchain_treasury.json) instead of fanning out to the `tdg_inventory_management` GAS on every page load.
- Three fetches collapse into one static JSON request. The GAS endpoints (`?list=true`, `?all_currencies=true`, `?manager=<key>`) remain wired as a **fallback** — if the cache URL fails or returns malformed JSON, the page behaves exactly as before.
- `?recipients=true` is **not touched** — it reads a separate sheet (Contributors contact information) that is outside the treasury cache.

## How it works

- `getTreasuryCache()` fetches the JSON once per page session (memoized promise, `cache: 'no-store'` + session-scoped bust query string so reloads get fresh data without re-fetching mid-session).
- Three adapters translate the cache schema back to the exact shapes the existing rendering code expects:
  - `getManagersFromTreasuryCache()` → `[{key, name}]`
  - `getAllCurrenciesFromTreasuryCache()` → `[{product_name, ledger_quantities, total_quantity, unit_weight_g, ...}]` (matches `listAllCurrenciesAcrossLedgers` shape, including the GAS convention of omitting `Main Ledger` from `ledger_quantities`).
  - `getManagerAssetsFromTreasuryCache(managerKey)` → `[{currency, amount, unit_cost?, total_value?, ledger?}]`
- No rendering, autocomplete, validation, QR, or submit logic changed. Diff is confined to the three loader functions.

## Pipeline context

1. `tokenomics/.../process_movement_telegram_logs.gs` notifies the treasury-cache-publisher on every `[INVENTORY MOVEMENT]` batch (tokenomics #230, merged).
2. `treasury-cache-publisher` Apps Script re-aggregates all ledgers and commits [`dao_offchain_treasury.json`](https://github.com/TrueSightDAO/treasury-cache/blob/main/dao_offchain_treasury.json) + [`SNAPSHOT.md`](https://github.com/TrueSightDAO/treasury-cache/blob/main/SNAPSHOT.md) to `main`. Safety-net cron runs every 30 min.
3. **This PR** — `report_inventory_movement.html` reads that JSON.

## Test plan

Manual browser validation — I haven't exercised the UI yet.

- [ ] Open [`report_inventory_movement.html`](https://dapp.truesight.me/report_inventory_movement.html) (or the GitHub Pages preview from this PR) with DevTools open.
- [ ] Console should log `[treasury-cache] loaded { generated_at, trigger, item_types, managers }`, then `[managers] loaded N via treasury-cache`, then `[all_currencies] loaded N via treasury-cache`.
- [ ] Warehouse Manager dropdown: same managers as before, loaded visibly faster.
- [ ] Inventory Item dropdown (before selecting a manager): full catalogue from treasury-cache.
- [ ] Select a manager → per-manager items populate from cache; console: `[manager_assets] loaded N via treasury-cache`.
- [ ] Spot-check: pick a manager known to hold AGL-prefixed items — `[AGLn] <asset>` entries appear alongside bare items.
- [ ] Submit a test movement; no regressions on the submit side (unchanged path).
- [ ] Fallback: temporarily block `raw.githubusercontent.com` in DevTools → reload → console logs `via gas` instead; page still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)