### PR TITLE
feat(dapp): extend treasury-cache reads to expenses + shipping planner

### DIFF
--- a/js/treasury_cache.js
+++ b/js/treasury_cache.js
@@ -1,0 +1,172 @@
+/**
+ * Shared treasury-cache loader + adapter helpers.
+ *
+ * Loads https://raw.githubusercontent.com/TrueSightDAO/treasury-cache/main/dao_offchain_treasury.json
+ * (refreshed on every [INVENTORY MOVEMENT] batch + 30-min safety-net cron) and
+ * exposes adapter functions that translate the schema back to the exact shapes
+ * the existing DApp pages already know how to render. Each consumer page falls
+ * back to its original GAS fetch on any failure.
+ *
+ * Schema: https://github.com/TrueSightDAO/treasury-cache/blob/main/README.md
+ *
+ * Usage on a page that already has `DAO_FORMS_BASE`:
+ *
+ *   <script src="js/treasury_cache.js"></script>
+ *   ...
+ *   const managers = (await TreasuryCache.getManagers()) ||
+ *                    await fetch(`${DAO_FORMS_BASE}?list=true`).then(r => r.json());
+ *
+ * All adapters return null when the cache couldn't be loaded, letting the
+ * caller decide how to fall back. They never throw.
+ */
+(function (global) {
+  'use strict';
+
+  var TREASURY_CACHE_BASE_URL =
+    'https://raw.githubusercontent.com/TrueSightDAO/treasury-cache/main/dao_offchain_treasury.json';
+  var TREASURY_CACHE_SESSION_BUST = Date.now(); // freshen per page load, memoize within session
+  var _promise = null;
+
+  function load() {
+    if (_promise) return _promise;
+    _promise = (async function () {
+      try {
+        var url = TREASURY_CACHE_BASE_URL + '?t=' + TREASURY_CACHE_SESSION_BUST;
+        var res = await fetch(url, { cache: 'no-store' });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        var json = await res.json();
+        if (!json || !Array.isArray(json.items) || !Array.isArray(json.managers)) {
+          throw new Error('malformed treasury-cache JSON');
+        }
+        console.log('[treasury-cache] loaded', {
+          generated_at: json.generated_at,
+          trigger: json.trigger,
+          schema_version: json.schema_version,
+          item_types: json.totals && json.totals.item_types,
+          managers: json.totals && json.totals.managers_count
+        });
+        return json;
+      } catch (err) {
+        console.warn('[treasury-cache] load failed, consumers will fall back to GAS:', err);
+        return null;
+      }
+    })();
+    return _promise;
+  }
+
+  // [{key, name}] — drop-in for DAO_FORMS_BASE?list=true
+  async function getManagers() {
+    var snap = await load();
+    if (!snap) return null;
+    return snap.managers.map(function (m) {
+      return { key: m.manager_key, name: m.manager_name };
+    });
+  }
+
+  // [{ledger_name, ledger_url}] — drop-in for DAO_FORMS_BASE?ledgers=true
+  async function getLedgers() {
+    var snap = await load();
+    if (!snap || !Array.isArray(snap.ledgers)) return null;
+    return snap.ledgers.map(function (l) {
+      return { ledger_name: l.ledger_name, ledger_url: l.ledger_url };
+    });
+  }
+
+  // {status:'success', data:{currencies:[…]}} — drop-in for DAO_FORMS_BASE?all_currencies=true.
+  // Excludes "Main Ledger" from ledger_quantities to match GAS response exactly.
+  async function getAllCurrencies() {
+    var snap = await load();
+    if (!snap) return null;
+    var currencies = snap.items.map(function (it) {
+      var lq = {};
+      Object.keys(it.ledgers || {}).forEach(function (k) {
+        if (k !== 'Main Ledger') lq[k] = it.ledgers[k];
+      });
+      return {
+        product_name: it.currency,
+        product_image: '',
+        landing_page: '',
+        ledger: '',
+        farm_name: '',
+        state: '',
+        country: '',
+        year: '',
+        unit_weight_g: it.unit_weight_g != null ? it.unit_weight_g : null,
+        total_quantity: it.total_quantity,
+        ledger_quantities: lq
+      };
+    });
+    return { status: 'success', data: { currencies: currencies, total_currencies: currencies.length } };
+  }
+
+  // [{currency, amount, unit_cost?, total_value?, ledger?}] — drop-in for
+  // DAO_FORMS_BASE?manager=<key> (report_inventory_movement, report_dao_expenses).
+  async function getManagerAssets(managerKey) {
+    var snap = await load();
+    if (!snap) return null;
+    var manager = snap.managers.find(function (m) { return m.manager_key === managerKey; });
+    if (!manager) return [];
+    return manager.items.map(function (itm) {
+      var out = { currency: itm.currency, amount: itm.amount };
+      if (itm.unit_cost_usd != null) out.unit_cost = itm.unit_cost_usd;
+      if (itm.total_value_usd != null) out.total_value = itm.total_value_usd;
+      if (itm.ledger) out.ledger = itm.ledger;
+      return out;
+    });
+  }
+
+  // {status:'success', data:{inventory:[{currency, amount, ledger_name, weight_grams, has_weight}]}}
+  // — drop-in for tdg_shipping_planner ?action=get_inventory&manager=<…>.
+  // Accepts either the raw manager name OR the URI-encoded key, matching
+  // whichever form the caller has on hand.
+  async function getManagerInventoryForShipping(managerIdentifier) {
+    var snap = await load();
+    if (!snap) return null;
+    var manager = snap.managers.find(function (m) {
+      return m.manager_name === managerIdentifier || m.manager_key === managerIdentifier;
+    });
+    if (!manager) {
+      try {
+        var decoded = decodeURIComponent(managerIdentifier);
+        manager = snap.managers.find(function (m) { return m.manager_name === decoded; });
+      } catch (_) { /* malformed URI component — give up */ }
+    }
+    var inventory = manager
+      ? manager.items.map(function (itm) {
+          return {
+            currency: itm.currency,
+            amount: itm.amount,
+            ledger_name: itm.ledger || '',
+            weight_grams: itm.unit_weight_g != null ? itm.unit_weight_g : null,
+            has_weight: itm.unit_weight_g != null
+          };
+        })
+      : [];
+    return { status: 'success', data: { inventory: inventory } };
+  }
+
+  // {status:'success', data:{managers:[{key, name}]}} — drop-in for
+  // tdg_shipping_planner ?action=list_managers (different wrap than DAO_FORMS_BASE).
+  async function getManagersForShipping() {
+    var snap = await load();
+    if (!snap) return null;
+    return {
+      status: 'success',
+      data: {
+        managers: snap.managers.map(function (m) {
+          return { key: m.manager_key, name: m.manager_name };
+        })
+      }
+    };
+  }
+
+  global.TreasuryCache = {
+    load: load,
+    getManagers: getManagers,
+    getLedgers: getLedgers,
+    getAllCurrencies: getAllCurrencies,
+    getManagerAssets: getManagerAssets,
+    getManagerInventoryForShipping: getManagerInventoryForShipping,
+    getManagersForShipping: getManagersForShipping
+  };
+})(window);

--- a/report_dao_expenses.html
+++ b/report_dao_expenses.html
@@ -19,6 +19,7 @@
     <script src="./menu.js"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./expense-form-utils.js"></script>
+    <script src="./js/treasury_cache.js"></script>
 
     <style>
         body {
@@ -601,8 +602,15 @@
         async function loadMembers() {
             const memberInput = document.getElementById('memberInput');
             try {
-                const res = await fetch(`${DAO_FORMS_BASE}?list=true`);
-                const members = await res.json();
+                let members = null;
+                try { members = await TreasuryCache.getManagers(); } catch (_) {}
+                let source = 'treasury-cache';
+                if (!members) {
+                    source = 'gas';
+                    const res = await fetch(`${DAO_FORMS_BASE}?list=true`);
+                    members = await res.json();
+                }
+                console.log(`[members] loaded ${members && members.length} via ${source}`);
                 allMembers = members || [];
                 const memberOptions = document.getElementById('memberOptions');
                 memberOptions.innerHTML = '';
@@ -633,8 +641,15 @@
         async function loadLedgers() {
             const ledgerInput = document.getElementById('ledgerInput');
             try {
-                const res = await fetch(`${DAO_FORMS_BASE}?ledgers=true`);
-                const ledgers = await res.json();
+                let ledgers = null;
+                try { ledgers = await TreasuryCache.getLedgers(); } catch (_) {}
+                let source = 'treasury-cache';
+                if (!ledgers) {
+                    source = 'gas';
+                    const res = await fetch(`${DAO_FORMS_BASE}?ledgers=true`);
+                    ledgers = await res.json();
+                }
+                console.log(`[ledgers] loaded ${ledgers && ledgers.length} via ${source}`);
                 allLedgers = ledgers || [];
                 const ledgerOptions = document.getElementById('ledgerOptions');
                 ledgerOptions.innerHTML = '';
@@ -1030,9 +1045,17 @@
             }
             
             try {
-                const res = await fetch(`${DAO_FORMS_BASE}?manager=${encodeURIComponent(memberKey)}`);
-                resources = await res.json();
-                console.log('Loaded member resources:', resources.length, resources);
+                let cachedResources = null;
+                try { cachedResources = await TreasuryCache.getManagerAssets(memberKey); } catch (_) {}
+                let source = 'treasury-cache';
+                if (cachedResources) {
+                    resources = cachedResources;
+                } else {
+                    source = 'gas';
+                    const res = await fetch(`${DAO_FORMS_BASE}?manager=${encodeURIComponent(memberKey)}`);
+                    resources = await res.json();
+                }
+                console.log(`[member_resources] loaded ${resources.length} via ${source}`);
                 console.log('All currencies available:', allCurrencies.length, allCurrencies);
                 
                 // Store all options with metadata for lookup (before filtering)
@@ -1154,13 +1177,19 @@
 
         async function loadAllCurrencies() {
             try {
-                const res = await fetch(`${DAO_FORMS_BASE}?all_currencies=true`);
-                const data = await res.json();
-                if (data.status === 'success') {
+                let data = null;
+                try { data = await TreasuryCache.getAllCurrencies(); } catch (_) {}
+                let source = 'treasury-cache';
+                if (!data) {
+                    source = 'gas';
+                    const res = await fetch(`${DAO_FORMS_BASE}?all_currencies=true`);
+                    data = await res.json();
+                }
+                if (data && data.status === 'success') {
                     allCurrencies = data.data.currencies || [];
-                    console.log('Loaded all currencies across ledgers:', allCurrencies.length, allCurrencies);
+                    console.log(`[all_currencies] loaded ${allCurrencies.length} via ${source}`);
                 } else {
-                    console.error('Error from listAllCurrenciesAcrossLedgers:', data.message);
+                    console.error('Error from listAllCurrenciesAcrossLedgers:', data && data.message);
                     allCurrencies = [];
                 }
             } catch (err) {

--- a/shipping_planner.html
+++ b/shipping_planner.html
@@ -55,6 +55,7 @@
     <script src="./routes.js"></script>
     <script src="./menu.js"></script>
     <script src="./tdg_balance.js"></script>
+    <script src="./js/treasury_cache.js"></script>
     
     <style>
         body {
@@ -1078,13 +1079,19 @@
                 const statusEl = document.getElementById('status');
                 statusEl.textContent = 'Loading managers...';
                 statusEl.className = 'loading';
-                
-                const url = API_BASE_URL + '?action=list_managers';
-                const response = await fetch(url);
-                const data = await response.json();
-                
+
+                let data = null;
+                try { data = await TreasuryCache.getManagersForShipping(); } catch (_) {}
+                let source = 'treasury-cache';
+                if (!data) {
+                    source = 'gas';
+                    const response = await fetch(API_BASE_URL + '?action=list_managers');
+                    data = await response.json();
+                }
+
                 if (data.status === 'success' && data.data.managers) {
                     managersList = data.data.managers;
+                    console.log(`[managers] loaded ${managersList.length} via ${source}`);
                     populateManagerSelect();
                     statusEl.textContent = 'Ready';
                     statusEl.className = 'status';
@@ -1210,13 +1217,20 @@
             try {
                 document.getElementById('status').textContent = 'Loading inventory...';
                 document.getElementById('status').className = 'loading';
-                
-                const url = API_BASE_URL + '?action=get_inventory&manager=' + encodeURIComponent(managerKey);
-                const response = await fetch(url);
-                const data = await response.json();
-                
+
+                let data = null;
+                try { data = await TreasuryCache.getManagerInventoryForShipping(managerKey); } catch (_) {}
+                let source = 'treasury-cache';
+                if (!data) {
+                    source = 'gas';
+                    const url = API_BASE_URL + '?action=get_inventory&manager=' + encodeURIComponent(managerKey);
+                    const response = await fetch(url);
+                    data = await response.json();
+                }
+
                 if (data.status === 'success' && data.data.inventory) {
                     inventoryList = data.data.inventory;
+                    console.log(`[get_inventory] loaded ${inventoryList.length} via ${source}`);
                     populateInventoryList();
                     document.getElementById('status').textContent = 'Ready';
                     document.getElementById('status').className = 'status';


### PR DESCRIPTION
## Summary

Picks up from #166 (report_inventory_movement cache swap) and extends the same pattern to the two other slow-loading pages. Introduces a shared `js/treasury_cache.js` module so new pages don't copy-paste the inline block.

## Changes

**New: `dapp/js/treasury_cache.js`** — shared loader + adapters for the treasury-cache JSON:
- `TreasuryCache.getManagers()` → `?list=true`
- `TreasuryCache.getLedgers()` → `?ledgers=true`
- `TreasuryCache.getAllCurrencies()` → `?all_currencies=true`
- `TreasuryCache.getManagerAssets(key)` → `?manager=<key>`
- `TreasuryCache.getManagersForShipping()` → shipping `?action=list_managers`
- `TreasuryCache.getManagerInventoryForShipping(identifier)` → shipping `?action=get_inventory`

All adapters return `null` on cache miss and never throw, letting each caller fall back to its original GAS path.

**`dapp/report_dao_expenses.html`** — cache-first on 4 fetches (all still fall back to `DAO_FORMS_BASE` on error):
- `loadMembers` (`?list=true`)
- `loadLedgers` (`?ledgers=true`)
- `loadAllCurrencies` (`?all_currencies=true`)
- `onMemberChange` (`?manager=<memberKey>`)

**`dapp/shipping_planner.html`** — cache-first on 2 fetches (fall back to `API_BASE_URL` GAS on error):
- `loadManagers` (`?action=list_managers`)
- `onManagerChange` get_inventory (`?action=get_inventory&manager=…`)

Left alone:
- `?recipients=true` (Contributors contact info — separate sheet, not cached)
- `?action=calculate_shipping` (interactive, user-selected items)
- Freight lanes index + per-lane snapshots on raw.githubusercontent.com (already static, already fast)
- `report_inventory_movement.html` (works with inline cache loader; can migrate to shared module later)

Schema dependency: needs treasury-cache **v2** (adds `unit_weight_g` to `managers[].items[]`) already published from 9934f55.

## Test plan

For each page, open with DevTools console:

**expenses** (`report_dao_expenses.html`):
- `[treasury-cache] loaded { schema_version: 2, item_types: 82, managers: 38 }`
- `[members] loaded N via treasury-cache`
- `[ledgers] loaded N via treasury-cache`
- `[all_currencies] loaded N via treasury-cache`
- Select a member → `[member_resources] loaded N via treasury-cache`

**shipping planner** (`shipping_planner.html`):
- `[treasury-cache] loaded ...`
- `[managers] loaded N via treasury-cache`
- Select a member → `[get_inventory] loaded N via treasury-cache` with weight_grams populated

Fallback check on either page: block `raw.githubusercontent.com` in DevTools → reload → console shows `via gas` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)