### PR TITLE
fix(dapp): open interaction history in new tab after Stores Nearby update

### DIFF
--- a/stores_nearby.html
+++ b/stores_nearby.html
@@ -6659,7 +6659,7 @@
                         messageElement.innerHTML =
                             `<span style="color: #28a745;">✅ ${escapeHtml(data.message || 'Updated')}</span>` +
                             `<div style="margin-top:0.5rem;font-size:0.9rem;line-height:1.4;">` +
-                            `<a href="${historyUrl}" style="color:#0d6efd;font-weight:600;">Open interaction history</a> ` +
+                            `<a href="${historyUrl}" target="_blank" rel="noopener noreferrer" style="color:#0d6efd;font-weight:600;">Open interaction history</a> ` +
                             `to review or edit details in one place (this list is not re-fetched so your scroll position stays put).` +
                             `</div>`;
                         


### PR DESCRIPTION
Small UX follow-up: after a successful Hit List `update_status` from Stores Nearby, the **Open interaction history** link now uses `target=_blank` + `rel=noopener noreferrer` so operators keep the map/list tab while reviewing details on `store_interaction_history.html`.

Related context already on `main`: post-update success copy + link to interaction history; Store Interaction History help text clarifying text-only updates and no photo attachments for now.

Made with [Cursor](https://cursor.com)