### PR TITLE
perf(tdg_balance): cache-first fetch against dao_members.json, GAS fallback

### DIFF
--- a/tdg_balance.js
+++ b/tdg_balance.js
@@ -9,6 +9,16 @@
  * See DAPP_PAGE_CONVENTIONS.md and UX_CONVENTIONS.md.
  */
 (function() {
+  // GitHub-raw cache (fast path). Published by the tdg_identity_management GAS
+  // project on every EMAIL VERIFICATION + contribution event (tokenomics#236 +
+  // sentiment_importer#1028). Shape: {contributors: [{name, voting_rights,
+  // asset_per_circulated_voting_right, public_keys: [{public_key, status, ...}]}]}.
+  // CDN-served, ~50–150ms TTFB vs 2–5s GAS cold-start.
+  const CACHE_URL = (window.Routes && window.Routes.daoMembersCache)
+      || 'https://raw.githubusercontent.com/TrueSightDAO/treasury-cache/main/dao_members.json';
+
+  // GAS assetVerify (source of truth; fallback when cache is absent, stale,
+  // or the current browser key is too fresh to appear in the last snapshot).
   const API_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
       || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
 
@@ -49,30 +59,85 @@
     container.innerHTML = '<span class="tdg-balance-loading" aria-live="polite">Loading your TDG holdings…</span>';
     container.className = 'tdg-balance-container tdg-balance-loading-state';
 
-    fetch(API_ENDPOINT + '?signature=' + encodeURIComponent(publicKey) + '&full=true')
-      .then(function(r) { return r.json(); })
+    // Try the GitHub-raw cache first; fall back to GAS if the cache is
+    // unavailable or if this browser's freshly-verified public key hasn't
+    // made it into the latest snapshot yet.
+    fetchFromCache(publicKey)
+      .catch(function() { return fetchFromGas(publicKey); })
       .then(function(data) {
-        if (data.error) {
+        if (!data || data.error) {
           container.innerHTML = '';
           container.className = 'tdg-balance-container';
           return;
         }
-        var votingRights = parseFloat(data.voting_rights);
-        var valuePerRight = parseFloat(data.asset_per_circulated_voting_right);
-        var totalValue = votingRights * valuePerRight;
-
-        container.innerHTML =
-          '<a href="./withdraw_voting_rights.html" class="tdg-balance-link" title="View details and cash out voting rights">' +
-          '<span class="tdg-balance-rights">' + formatRights(votingRights) + ' voting rights</span>' +
-          '<span class="tdg-balance-sep">·</span>' +
-          '<span class="tdg-balance-value">~$' + formatUsd(totalValue) + ' est. cash-out value</span>' +
-          '</a>';
-        container.className = 'tdg-balance-container tdg-balance-verified';
+        renderBadge(container, data);
       })
       .catch(function() {
         container.innerHTML = '';
         container.className = 'tdg-balance-container';
       });
+  }
+
+  function fetchFromCache(publicKey) {
+    return fetch(CACHE_URL, { cache: 'no-cache' })
+      .then(function(r) {
+        if (!r.ok) throw new Error('cache HTTP ' + r.status);
+        return r.json();
+      })
+      .then(function(snapshot) {
+        // DAO-wide ratio used to turn voting_rights into USD. Must live at the
+        // snapshot root (it's not per-contributor). If missing, treat the whole
+        // cache hit as incomplete and fall back to GAS — keeps the badge honest
+        // while the publisher is being upgraded.
+        var daoTotals = (snapshot && snapshot.dao_totals) || {};
+        var assetPerRight = parseFloat(daoTotals.asset_per_circulated_voting_right);
+        if (!isFinite(assetPerRight)) throw new Error('cache missing dao_totals.asset_per_circulated_voting_right');
+
+        var contributors = (snapshot && snapshot.contributors) || [];
+        for (var i = 0; i < contributors.length; i++) {
+          var c = contributors[i];
+          var keys = (c && c.public_keys) || [];
+          for (var j = 0; j < keys.length; j++) {
+            if (keys[j] && keys[j].public_key === publicKey) {
+              return {
+                contributor_name: c.name,
+                voting_rights: c.voting_rights,
+                asset_per_circulated_voting_right: assetPerRight,
+                _source: 'github_cache'
+              };
+            }
+          }
+        }
+        throw new Error('cache miss: public key not found in snapshot');
+      });
+  }
+
+  function fetchFromGas(publicKey) {
+    return fetch(API_ENDPOINT + '?signature=' + encodeURIComponent(publicKey) + '&full=true')
+      .then(function(r) { return r.json(); })
+      .then(function(data) {
+        if (data) data._source = 'gas';
+        return data;
+      });
+  }
+
+  function renderBadge(container, data) {
+    var votingRights = parseFloat(data.voting_rights);
+    var valuePerRight = parseFloat(data.asset_per_circulated_voting_right);
+    if (!isFinite(votingRights) || !isFinite(valuePerRight)) {
+      container.innerHTML = '';
+      container.className = 'tdg-balance-container';
+      return;
+    }
+    var totalValue = votingRights * valuePerRight;
+
+    container.innerHTML =
+      '<a href="./withdraw_voting_rights.html" class="tdg-balance-link" title="View details and cash out voting rights">' +
+      '<span class="tdg-balance-rights">' + formatRights(votingRights) + ' voting rights</span>' +
+      '<span class="tdg-balance-sep">·</span>' +
+      '<span class="tdg-balance-value">~$' + formatUsd(totalValue) + ' est. cash-out value</span>' +
+      '</a>';
+    container.className = 'tdg-balance-container tdg-balance-verified';
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary

\`tdg_balance.js\` was blocking the balance badge render on a 2–5 s GAS cold start on every DApp page load. This PR swaps it to a **cache-first / GAS-fallback** fetch:

1. **Fast path** — GET \`raw.githubusercontent.com/TrueSightDAO/treasury-cache/main/dao_members.json\` (CDN-served, TTFB 50–150 ms). Scan \`contributors[*].public_keys[*]\` for the current \`localStorage.publicKey\`. If found and the snapshot has \`dao_totals.asset_per_circulated_voting_right\`, render from cache — typical ~20× faster.
2. **Fallback** — On any cache miss (404 while the publisher hasn't run yet, key too freshly-verified to be in the last snapshot, incomplete snapshot shape), fall through to the existing \`assetVerify\` GAS fetch. Identical behaviour to today for that path.

## Plumbing context

- [tokenomics#236](https://github.com/TrueSightDAO/tokenomics/pull/236) shipped the GAS publisher (\`dao_members_cache_publisher.gs\`) that writes \`dao_members.json\` via the \`tdg_identity_management\` project's \`doGet\`.
- [sentiment_importer#1028](https://github.com/TrueSightDAO/sentiment_importer/pull/1028) added \`DaoMembersCacheRefreshWorker\` so a newly-verified public key triggers a cache refresh within seconds (plus daily safety-net cron in the GAS).
- Until an operator runs \`publishDaoMembersCacheNow()\` once to produce the first \`dao_members.json\` commit, this code's fast path always 404s and falls back to GAS — **no regression during the rollout**.

## One known gap — will follow up

The current GAS publisher doesn't yet emit \`dao_totals.asset_per_circulated_voting_right\` at the snapshot root. This PR treats its absence as a cache miss on purpose (badge renders correctly via GAS) — I'll ship a small tokenomics follow-up to add the DAO-wide totals so the fast path actually activates.

## Test plan

- [x] \`node --check tdg_balance.js\` passes.
- [ ] Load any DApp page before the GAS publisher has run. Expect: badge renders via GAS (network tab shows one 404 on raw.githubusercontent.com followed by a 200 on script.google.com).
- [ ] After publisher runs + emits DAO totals. Expect: badge renders from cache (single 200 on raw.githubusercontent.com; no GAS traffic).
- [ ] Register a brand-new browser key and load a page immediately (before the Sidekiq cache-refresh completes). Expect: cache hit fails on public-key scan, falls back to GAS, badge still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)