### PR TITLE
perf(dapp): shared DaoMembersCache + cache-first signature check on create_signature

### DIFF
--- a/create_signature.html
+++ b/create_signature.html
@@ -17,6 +17,7 @@
   
   <script src="./routes.js"></script>
   <script src="./menu.js"></script>
+  <script src="./scripts/dao_members_cache.js"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/edgar_payload_helper.js"></script>
   <style>
@@ -821,6 +822,27 @@
           verifyBtn.click();
         }, 0);
         return;
+      }
+
+      // Optimistic first render from the GitHub-raw dao_members.json cache
+      // (CDN ~50–150ms) while Edgar's check_digital_signature call is in
+      // flight (~300–800ms warm, more if the route is cold). If the cache
+      // shows the key as ACTIVE we render "Welcome back" immediately; the
+      // subsequent Edgar response either refines it with the registered
+      // email (via applyRegisteredUi below) or, in the rare stale-cache
+      // case, overrides it with the authoritative unregistered / pending
+      // UI. On any cache miss / fetch error we silently skip — the Edgar
+      // path below renders the correct UI regardless.
+      let optimisticRegisteredApplied = false;
+      if (window.DaoMembersCache && window.DaoMembersCache.findByPublicKey) {
+        window.DaoMembersCache.findByPublicKey(publicKey)
+          .then((hit) => {
+            if (!hit || !hit.contributor || !hit.key) return;
+            if (String(hit.key.status || '').toUpperCase() !== 'ACTIVE') return;
+            optimisticRegisteredApplied = true;
+            applyRegisteredUi({ contributor_name: hit.contributor.name, contributor_email: '' });
+          })
+          .catch(() => { /* cache unavailable — Edgar path is canonical */ });
       }
 
       const data = await checkSignatureRegistration(publicKey);

--- a/scripts/dao_members_cache.js
+++ b/scripts/dao_members_cache.js
@@ -1,0 +1,89 @@
+/**
+ * DaoMembersCache — shared session-memoized fetch of dao_members.json.
+ *
+ * Source: https://raw.githubusercontent.com/TrueSightDAO/treasury-cache/main/dao_members.json
+ * Published by tokenomics/google_app_scripts/tdg_identity_management/dao_members_cache_publisher.gs
+ * on every EMAIL VERIFICATION activation (sentiment_importer#1028) + daily cron.
+ *
+ * One in-flight promise is shared across all callers on a page, so multiple
+ * DApp components (tdg_balance.js, create_signature.html) fetch the snapshot
+ * at most once per page load regardless of how many consumers need it.
+ *
+ * Exposes:
+ *   window.DaoMembersCache.fetchSnapshot()
+ *       → Promise<snapshot JSON>.
+ *   window.DaoMembersCache.findByPublicKey(pk)
+ *       → Promise<{contributor, key, daoTotals, snapshot}>, fields null on miss.
+ *   window.DaoMembersCache.invalidate()
+ *       → drops the memoized promise; next call refetches.
+ *   window.DaoMembersCache.DEFAULT_URL — the raw.githubusercontent.com URL.
+ *
+ * Callers opt in to the cache; graceful-fallback behaviour (to GAS / Edgar)
+ * is each caller's responsibility since the right fallback differs by page.
+ */
+(function (global) {
+  const DEFAULT_URL =
+      'https://raw.githubusercontent.com/TrueSightDAO/treasury-cache/main/dao_members.json';
+
+  let cachedPromise = null;
+  let cachedUrl = null;
+
+  function resolveUrl() {
+    return (global.Routes && global.Routes.daoMembersCache) || DEFAULT_URL;
+  }
+
+  function fetchSnapshot() {
+    const url = resolveUrl();
+    if (cachedPromise && cachedUrl === url) return cachedPromise;
+    cachedUrl = url;
+    cachedPromise = global.fetch(url, { cache: 'no-cache' }).then(function (resp) {
+      if (!resp.ok) {
+        cachedPromise = null; // don't pin a bad response for the rest of the session
+        throw new Error('dao_members.json HTTP ' + resp.status);
+      }
+      return resp.json();
+    }).catch(function (err) {
+      cachedPromise = null;
+      throw err;
+    });
+    return cachedPromise;
+  }
+
+  function findByPublicKey(publicKey) {
+    return fetchSnapshot().then(function (snapshot) {
+      const contributors = (snapshot && snapshot.contributors) || [];
+      for (let i = 0; i < contributors.length; i++) {
+        const c = contributors[i];
+        const keys = (c && c.public_keys) || [];
+        for (let j = 0; j < keys.length; j++) {
+          if (keys[j] && keys[j].public_key === publicKey) {
+            return {
+              contributor: c,
+              key: keys[j],
+              daoTotals: (snapshot && snapshot.dao_totals) || null,
+              snapshot: snapshot
+            };
+          }
+        }
+      }
+      return {
+        contributor: null,
+        key: null,
+        daoTotals: (snapshot && snapshot.dao_totals) || null,
+        snapshot: snapshot
+      };
+    });
+  }
+
+  function invalidate() {
+    cachedPromise = null;
+    cachedUrl = null;
+  }
+
+  global.DaoMembersCache = {
+    DEFAULT_URL: DEFAULT_URL,
+    fetchSnapshot: fetchSnapshot,
+    findByPublicKey: findByPublicKey,
+    invalidate: invalidate
+  };
+})(window);

--- a/tdg_balance.js
+++ b/tdg_balance.js
@@ -79,37 +79,50 @@
   }
 
   function fetchFromCache(publicKey) {
-    return fetch(CACHE_URL, { cache: 'no-cache' })
-      .then(function(r) {
-        if (!r.ok) throw new Error('cache HTTP ' + r.status);
-        return r.json();
-      })
-      .then(function(snapshot) {
-        // DAO-wide ratio used to turn voting_rights into USD. Must live at the
-        // snapshot root (it's not per-contributor). If missing, treat the whole
-        // cache hit as incomplete and fall back to GAS — keeps the badge honest
-        // while the publisher is being upgraded.
-        var daoTotals = (snapshot && snapshot.dao_totals) || {};
-        var assetPerRight = parseFloat(daoTotals.asset_per_circulated_voting_right);
-        if (!isFinite(assetPerRight)) throw new Error('cache missing dao_totals.asset_per_circulated_voting_right');
+    // Prefer the shared DaoMembersCache helper (session-memoized across
+    // components on the page). Fall back to an inline fetch so tdg_balance.js
+    // keeps working on pages that don't load scripts/dao_members_cache.js.
+    const fetcher = (window.DaoMembersCache && window.DaoMembersCache.findByPublicKey)
+      ? window.DaoMembersCache.findByPublicKey(publicKey).then(function(hit) {
+          if (!hit || !hit.contributor) throw new Error('cache miss: public key not found in snapshot');
+          const daoTotals = hit.daoTotals || {};
+          const assetPerRight = parseFloat(daoTotals.asset_per_circulated_voting_right);
+          if (!isFinite(assetPerRight)) throw new Error('cache missing dao_totals.asset_per_circulated_voting_right');
+          return {
+            contributor_name: hit.contributor.name,
+            voting_rights: hit.contributor.voting_rights,
+            asset_per_circulated_voting_right: assetPerRight,
+            _source: 'github_cache'
+          };
+        })
+      : fetch(CACHE_URL, { cache: 'no-cache' })
+          .then(function(r) {
+            if (!r.ok) throw new Error('cache HTTP ' + r.status);
+            return r.json();
+          })
+          .then(function(snapshot) {
+            var daoTotals = (snapshot && snapshot.dao_totals) || {};
+            var assetPerRight = parseFloat(daoTotals.asset_per_circulated_voting_right);
+            if (!isFinite(assetPerRight)) throw new Error('cache missing dao_totals.asset_per_circulated_voting_right');
 
-        var contributors = (snapshot && snapshot.contributors) || [];
-        for (var i = 0; i < contributors.length; i++) {
-          var c = contributors[i];
-          var keys = (c && c.public_keys) || [];
-          for (var j = 0; j < keys.length; j++) {
-            if (keys[j] && keys[j].public_key === publicKey) {
-              return {
-                contributor_name: c.name,
-                voting_rights: c.voting_rights,
-                asset_per_circulated_voting_right: assetPerRight,
-                _source: 'github_cache'
-              };
+            var contributors = (snapshot && snapshot.contributors) || [];
+            for (var i = 0; i < contributors.length; i++) {
+              var c = contributors[i];
+              var keys = (c && c.public_keys) || [];
+              for (var j = 0; j < keys.length; j++) {
+                if (keys[j] && keys[j].public_key === publicKey) {
+                  return {
+                    contributor_name: c.name,
+                    voting_rights: c.voting_rights,
+                    asset_per_circulated_voting_right: assetPerRight,
+                    _source: 'github_cache_inline'
+                  };
+                }
+              }
             }
-          }
-        }
-        throw new Error('cache miss: public key not found in snapshot');
-      });
+            throw new Error('cache miss: public key not found in snapshot');
+          });
+    return fetcher;
   }
 
   function fetchFromGas(publicKey) {


### PR DESCRIPTION
## Summary

Speeds up \`create_signature.html\`'s first render for returning contributors by consulting the \`dao_members.json\` cache in parallel with Edgar's \`check_digital_signature\` call. Also extracts the cache fetch into a shared helper so \`tdg_balance.js\` and \`create_signature.html\` share a single HTTP request per page load.

## What ships

- **\`scripts/dao_members_cache.js\`** — new shared helper with session-memoized \`findByPublicKey(pk)\` / \`fetchSnapshot()\` / \`invalidate()\`.
- **\`tdg_balance.js\`** — now prefers the shared helper; falls back to its own inline fetch on pages that haven't adopted the helper yet. No behaviour regression.
- **\`create_signature.html\`** — kicks off the cache lookup in parallel with the Edgar check; renders \"Welcome back\" from the cache the moment it resolves (no email line yet), then Edgar's response refines to include the registered email. Stale-cache case is covered: if Edgar says the key is unregistered or pending, that overrides the optimistic cache render.

## Latency win

Returning-user case on an active key:

- **Before:** block UI on \`check_digital_signature\` (Edgar, Rails) — typical 300–800 ms warm.
- **After:** render welcome from \`raw.githubusercontent.com\` — typical 50–150 ms TTFB.

For newly verified keys (Sidekiq hasn't refreshed yet), for unregistered keys, and for pending-verification keys, behaviour is **unchanged** — Edgar remains authoritative.

## Test plan

- [x] \`node --check\` passes on all three files.
- [ ] Load \`create_signature.html\` with an ACTIVE key in localStorage → welcome banner renders before the balance badge's GAS call would have landed; Edgar confirms and fills the email line.
- [ ] Load with an unregistered key → no optimistic render; Edgar path renders \"not registered\" as today.
- [ ] Load with a key that just verified in the last ~30 s → cache may miss; Edgar returns registered; flow renders welcome + email. No regression.
- [ ] Network tab: at most one GET to \`raw.githubusercontent.com/.../dao_members.json\` even when both the badge and the signature check consult the cache on the same page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)