### PR TITLE
Stores pages: uncached GAS fetches + interaction history footer links

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,26 @@
 importScripts('./routes.js');
 
-const CACHE_NAME = 'qr-scanner-cache-v3';
+const CACHE_NAME = 'qr-scanner-cache-v4';
+
+/**
+ * Apps Script web apps + Edgar GAS proxy — must not use the Cache API or HTTP cache
+ * for JSON list responses. exec URLs redirect to script.googleusercontent.com; those
+ * hops were previously handled by the default fetch handler and could serve stale data.
+ */
+function isGasOrProxyGasUrl(url) {
+  const host = url.hostname;
+  const path = url.pathname;
+  if (host === 'script.google.com' && (path.startsWith('/macros/s/') || path.startsWith('/a/macros/'))) {
+    return true;
+  }
+  if (host === 'script.googleusercontent.com' && path.includes('/macros/')) {
+    return true;
+  }
+  if (host === 'edgar.truesight.me' && path.startsWith('/proxy/gas/')) {
+    return true;
+  }
+  return false;
+}
 const URLS_TO_CACHE = [
   // HTML pages
   './',
@@ -41,9 +61,20 @@ self.addEventListener('install', event => {
   );
 });
 
-// Activate event: take control immediately
+// Activate event: drop older qr-scanner-cache-* entries so stale GAS responses are not kept.
 self.addEventListener('activate', event => {
-  event.waitUntil(self.clients.claim());
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((k) => k.startsWith('qr-scanner-cache-') && k !== CACHE_NAME)
+            .map((k) => caches.delete(k))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
 });
 
 // Fetch event: serve from cache, update on network; support reload param
@@ -64,20 +95,10 @@ self.addEventListener('fetch', event => {
     );
     return;
   }
-  // Handle Google Apps Script API calls: network-first with cache fallback.
-  // Matches both '/macros/s/<id>/exec' and the workspace-scoped
-  // '/a/macros/<domain>/s/<id>/exec' variant used by the Proposals GAS.
-  if (url.origin === 'https://script.google.com'
-      && (url.pathname.startsWith('/macros/s/') || url.pathname.startsWith('/a/macros/'))) {
-    event.respondWith(
-      fetch(request)
-        .then(response => {
-          const responseClone = response.clone();
-          caches.open(CACHE_NAME).then(cache => cache.put(request, responseClone));
-          return response;
-        })
-        .catch(() => caches.match(request))
-    );
+  // Google Apps Script + Edgar /proxy/gas: network-only, never Cache-API or disk cache.
+  // (Stores nearby and other live lists must always hit the wire.)
+  if (isGasOrProxyGasUrl(url)) {
+    event.respondWith(fetch(request, { cache: 'no-store' }));
     return;
   }
   // Default: network-first strategy for all other requests, fallback to cache if offline

--- a/store_interaction_history.html
+++ b/store_interaction_history.html
@@ -483,6 +483,12 @@
         </div>
 
         <div id="results"></div>
+
+        <p style="text-align: center; font-size: 0.95rem; margin: 1.5rem 0 0.25rem;">
+            <a href="https://docs.google.com/spreadsheets/d/1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc/edit?gid=1606881029#gid=1606881029" target="_blank" rel="noopener noreferrer" class="store-details-link">Pipeline Dashboard (sheet) ↗</a>
+            ·
+            <a href="./stores_by_status.html" class="store-details-link">Stores by Status ↗</a>
+        </p>
     </div>
 
     <script>
@@ -502,6 +508,9 @@
     /** Same as stores_nearby.html SIGNATURE_VERIFY_API */
     var SIGNATURE_VERIFY_API = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
         || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+
+    /** Bypass HTTP cache for live GAS JSON (aligned with service-worker GAS policy). */
+    var GAS_FETCH_INIT = { cache: 'no-store' };
 
     var searchInput = document.getElementById('storeSearch');
     var suggestPanel = document.getElementById('suggestPanel');
@@ -1051,7 +1060,7 @@
     async function fetchSuggestions(q) {
         if (!apiConfigured()) return;
         var url = API_BASE_URL + '?action=suggestStores&q=' + encodeURIComponent(q) + tokenQs();
-        var r = await fetch(url);
+        var r = await fetch(url, GAS_FETCH_INIT);
         var j = await r.json();
         if (j.status !== 'success') throw new Error(j.message || 'Suggest failed');
         return j.data.suggestions || [];
@@ -1061,7 +1070,7 @@
         if (!apiConfigured()) throw new Error('API URL not configured.');
         var url = API_BASE_URL + '?action=getStoreHistory&store_key=' + encodeURIComponent(storeKey || '') +
             '&shop=' + encodeURIComponent(shop || '') + tokenQs();
-        var r = await fetch(url);
+        var r = await fetch(url, GAS_FETCH_INIT);
         var j = await r.json();
         if (j.status !== 'success') throw new Error(j.message || 'History failed');
         return j.data;
@@ -1260,7 +1269,7 @@
             params.append('submitted_by', publicKey);
         }
 
-        fetch(STORES_NEARBY_API_URL + '?' + params.toString())
+        fetch(STORES_NEARBY_API_URL + '?' + params.toString(), GAS_FETCH_INIT)
             .then(function (r) { return r.json(); })
             .then(function (data) {
                 if (data.success) {
@@ -1298,7 +1307,10 @@
 
             var controller = new AbortController();
             var to = setTimeout(function () { controller.abort(); }, 10000);
-            var response = await fetch(SIGNATURE_VERIFY_API + '?signature=' + encodeURIComponent(publicKey), { signal: controller.signal });
+            var response = await fetch(SIGNATURE_VERIFY_API + '?signature=' + encodeURIComponent(publicKey), {
+                signal: controller.signal,
+                cache: 'no-store'
+            });
             clearTimeout(to);
 
             if (!response.ok) {

--- a/stores_by_status.html
+++ b/stores_by_status.html
@@ -329,6 +329,9 @@
         || 'https://script.google.com/macros/s/AKfycbwoBqZnDS4JRRdFkxSXdlGt-qIn-RauMcORuDHeWs29oQ2CpJ3L4A10uM8se9anL108/exec';
     var API_TOKEN = '';
 
+    /** Bypass HTTP cache for live GAS JSON (aligned with service-worker GAS policy). */
+    var GAS_FETCH_INIT = { cache: 'no-store' };
+
     var STATUS_OPTIONS = [
         'Research',
         'AI: Shortlisted',
@@ -624,7 +627,7 @@
         if (pipelineMeta) pipelineMeta.textContent = '';
         try {
             var url = API_BASE_URL + '?action=listStatusSummary' + tokenQs();
-            var res = await fetch(url);
+            var res = await fetch(url, GAS_FETCH_INIT);
             var json = await res.json();
             if (json.status !== 'success') {
                 var m = (json.message || '').toString();
@@ -712,7 +715,7 @@
         setLoadingUi(true);
         try {
             var url = buildListUrl();
-            var res = await fetch(url);
+            var res = await fetch(url, GAS_FETCH_INIT);
             var json = await res.json();
             if (json.status !== 'success') {
                 setStatus(json.message || 'Request failed', 'error');

--- a/stores_nearby.html
+++ b/stores_nearby.html
@@ -1441,7 +1441,10 @@
         const API_URL = (window.Routes && window.Routes.gas && window.Routes.gas.stores)
             || 'https://script.google.com/macros/s/AKfycbwB2zqNV9nMCMWs2hSa8FecjA36Oh-mSVuz3pk8TpXrXcy9dvqOqgbWIirNka2LmacgPw/exec';
         const SIGNATURE_VERIFY_API = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
-            || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';        
+            || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
+
+        /** Bypass HTTP cache for live GAS JSON (matches service worker network-only GAS policy). */
+        const GAS_FETCH_INIT = { cache: 'no-store' };
 
         const stateNameLookup = {
             'alabama': 'AL', 'alaska': 'AK', 'arizona': 'AZ', 'arkansas': 'AR',
@@ -2542,7 +2545,7 @@
                 maybeAttachFieldAgentLocationParams(params);
                 maybeAttachOpenNowParams(params);
                 
-                const response = await fetch(`${API_URL}?${params.toString()}`);
+                const response = await fetch(`${API_URL}?${params.toString()}`, GAS_FETCH_INIT);
                 const data = await response.json();
                 applyFieldAgentLocationResponse(data);
                 
@@ -3516,7 +3519,8 @@
                 const timeoutId = setTimeout(() => controller.abort(), 10000); // 10 second timeout
                 
                 const response = await fetch(`${SIGNATURE_VERIFY_API}?signature=${encodeURIComponent(publicKey)}`, {
-                    signal: controller.signal
+                    signal: controller.signal,
+                    cache: 'no-store'
                 });
                 clearTimeout(timeoutId);
                 
@@ -4844,7 +4848,7 @@
             maybeAttachOpenNowParams(params);
 
             // Fetch stores
-            fetch(`${API_URL}?${params.toString()}`)
+            fetch(`${API_URL}?${params.toString()}`, GAS_FETCH_INIT)
                 .then(response => response.json())
                 .then(data => {
                     document.getElementById('searchBtn').disabled = false;
@@ -6089,7 +6093,7 @@
             if (submitBtn) submitBtn.disabled = true;
 
             try {
-                const response = await fetch(`${API_URL}?${params.toString()}`);
+                const response = await fetch(`${API_URL}?${params.toString()}`, GAS_FETCH_INIT);
                 const data = await response.json();
                 if (data.success) {
                     if (messageEl) {
@@ -6651,7 +6655,7 @@
             }
 
             // Call API to update status
-            fetch(`${API_URL}?${params.toString()}`)
+            fetch(`${API_URL}?${params.toString()}`, GAS_FETCH_INIT)
                 .then(response => response.json())
                 .then(data => {
                     if (data.success) {


### PR DESCRIPTION
## Summary
- **Service worker (`service-worker.js`)**: GAS and Edgar `/proxy/gas` requests use `fetch(..., { cache: 'no-store' })` only—no Cache API writes or stale fallbacks. Covers `script.googleusercontent.com` redirect targets. Cache bucket bumped to `qr-scanner-cache-v4`; activate prunes older `qr-scanner-cache-*` keys.
- **`stores_nearby.html`**: (from prior work in same branch) `GAS_FETCH_INIT` on store list / update / verify fetches.
- **`stores_by_status.html`**: Same `cache: 'no-store'` for pipeline summary and filtered list fetches.
- **`store_interaction_history.html`**: Same for suggest, history, update, and signature verify; **footer** adds [Pipeline Dashboard (sheet)](https://docs.google.com/spreadsheets/d/1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc/edit?gid=1606881029#gid=1606881029) and **Stores by Status** (`./stores_by_status.html`) under the results block—matching the extra nav links on [Stores by Status](https://dapp.truesight.me/stores_by_status.html).

## Deploy
Merge to `main` and publish `dapp.truesight.me` as usual; users may need one navigation or refresh to pick up SW v4.

Made with [Cursor](https://cursor.com)