### PR TITLE
Store Interaction History: open in new tab from links and menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -334,7 +334,7 @@
         </ol>
       </div>
       <div class="module-card">
-        <h3><a href="./store_interaction_history.html">Store Interaction History</a></h3>
+        <h3><a href="./store_interaction_history.html" target="_blank" rel="noopener noreferrer">Store Interaction History</a></h3>
         <p>Review holistic wellness Hit List context (follow-ups, DApp remarks, email agent tabs) before partner outreach.</p>
         <p><strong>Features</strong>:</p>
         <ul>
@@ -343,7 +343,7 @@
         </ul>
         <p><strong>Usage</strong>:</p>
         <ol>
-          <li>Open <a href="./store_interaction_history.html">Store Interaction History</a>.</li>
+          <li>Open <a href="./store_interaction_history.html" target="_blank" rel="noopener noreferrer">Store Interaction History</a>.</li>
           <li>Search and expand rows as needed.</li>
         </ol>
       </div>

--- a/menu.js
+++ b/menu.js
@@ -68,8 +68,29 @@
         parent.appendChild(option);
       });
     });
-    select.addEventListener('change', function() {
-      location.href = this.value;
+    function selectOptionMatchingCurrentPage() {
+      var currentPage = location.pathname.split('/').pop();
+      var isProposalPage = currentPage === 'review_proposal.html' || currentPage === 'create_proposal.html';
+      for (var i = 0; i < select.options.length; i++) {
+        var opt = select.options[i];
+        var itemPage = (opt.value || '').split('/').pop();
+        var isDAOProposalManagement = opt.textContent === 'DAO Proposal Management';
+        if (itemPage === currentPage || (isProposalPage && isDAOProposalManagement)) {
+          select.selectedIndex = i;
+          return;
+        }
+      }
+    }
+    select.addEventListener('change', function () {
+      var url = this.value;
+      if (!url) return;
+      var isHistory = url.indexOf('store_interaction_history.html') !== -1;
+      if (isHistory) {
+        window.open(new URL(url, window.location.href).href, '_blank', 'noopener,noreferrer');
+        selectOptionMatchingCurrentPage();
+        return;
+      }
+      location.href = url;
     });
     container.appendChild(select);
   });

--- a/stores_by_status.html
+++ b/stores_by_status.html
@@ -290,7 +290,7 @@
             ·
             <a href="https://docs.google.com/spreadsheets/d/1eiqZr3LW-qEI6Hmy0Vrur_8flbRwxwA7jXVrbUnHbvc/edit?gid=1606881029#gid=1606881029" target="_blank" rel="noopener noreferrer" class="store-details-link">Pipeline Dashboard (sheet) ↗</a>
             ·
-            <a href="./store_interaction_history.html" class="store-details-link">Store Interaction History ↗</a>
+            <a href="./store_interaction_history.html" target="_blank" rel="noopener noreferrer" class="store-details-link">Store Interaction History ↗</a>
         </p>
 
         <div id="pipelineOverview" aria-live="polite">

--- a/stores_nearby.html
+++ b/stores_nearby.html
@@ -2683,7 +2683,7 @@
                     <strong>Distance:</strong> ${store.distance ? store.distance.toFixed(1) : 'N/A'} miles<br>
                     <a href="${mapsUrl}" target="_blank" style="color: #007bff; text-decoration: none; margin-right: 0.5rem;">📍 View on Google Maps</a>
                     ${store.instagram ? `<a href="${escapeHtml(store.instagram)}" target="_blank" style="color: #E4405F; text-decoration: none;">📷 View Instagram</a>` : ''}
-                    <br><a href="${escapeHtml(historyUrl)}" style="color: #0d6efd; text-decoration: none; font-weight: 600;">🗂️ Interaction history &amp; full edit</a>
+                    <br><a href="${escapeHtml(historyUrl)}" target="_blank" rel="noopener noreferrer" style="color: #0d6efd; text-decoration: none; font-weight: 600;">🗂️ Interaction history &amp; full edit</a>
                 `);
 
                 storeMarkers.push(marker);
@@ -3385,7 +3385,7 @@
                         <strong>Distance from you:</strong> ${store.distance} miles<br>                                                                         
                         <a href="${mapsUrl}" target="_blank" style="color: #007bff; text-decoration: none; margin-right: 0.5rem;">📍 View on Google Maps</a>
                         ${store.instagram ? `<a href="${escapeHtml(store.instagram)}" target="_blank" style="color: #E4405F; text-decoration: none;">📷 View Instagram</a>` : ''}
-                        <br><a href="${escapeHtml(historyUrl)}" style="color: #0d6efd; text-decoration: none; font-weight: 600;">🗂️ Interaction history &amp; full edit</a>
+                        <br><a href="${escapeHtml(historyUrl)}" target="_blank" rel="noopener noreferrer" style="color: #0d6efd; text-decoration: none; font-weight: 600;">🗂️ Interaction history &amp; full edit</a>
                     `);
 
                     storeMarkers.push(marker);
@@ -6170,7 +6170,7 @@
                 <div class="store-details-section">
                     <div class="store-details-title">🗂️ Hit list workspace</div>
                     <div class="store-details-content">
-                        <a href="${interactionHistoryUrl}" class="store-details-link" style="font-weight: 600;">Open interaction history</a>
+                        <a href="${interactionHistoryUrl}" target="_blank" rel="noopener noreferrer" class="store-details-link" style="font-weight: 600;">Open interaction history</a>
                         <span style="color: #555; font-size: 0.9rem;"> — full notes, email-agent context, and status updates without refreshing this list.</span>
                     </div>
                 </div>


### PR DESCRIPTION
Open store_interaction_history in a new tab from index and stores_by_status links, stores_nearby map/details links, and the nav menu. Menu uses window.open then restores the dropdown to the current page so map/filter state stays on mobile.

Made with [Cursor](https://cursor.com)