### PR TITLE
chat: reclaim mobile vertical space + fix media-query cascade

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -56,46 +56,6 @@
             height: auto;
             max-height: 120px;
         }
-        @media (max-width: 600px) {
-            .container {
-                padding: 0.25rem 0.5rem;
-            }
-            #logo {
-                max-height: 60px;
-            }
-            h1 {
-                font-size: 1.2rem;
-                margin: 0.2rem 0 0.3rem;
-            }
-            #description {
-                font-size: 0.8rem;
-                margin: 0.2rem 0 0.3rem;
-                line-height: 1.35;
-            }
-            #status {
-                margin: 0.2rem 0;
-                min-height: 18px;
-                font-size: 0.85rem;
-            }
-            #chat-messages {
-                padding: 0.5rem;
-                margin-bottom: 0.5rem;
-            }
-            .message {
-                max-width: 95%;
-                padding: 0.5rem 0.75rem;
-                margin-bottom: 0.5rem;
-            }
-            #chat-input {
-                min-height: 44px;
-                font-size: 16px; /* prevents iOS zoom */
-                padding: 0.5rem;
-            }
-            .btn {
-                padding: 0.5rem 0.75rem;
-                font-size: 1rem;
-            }
-        }
         h1 {
             font-size: 1.8rem;
             color: #333;
@@ -141,7 +101,8 @@
             border-radius: 12px;
             max-width: 85%;
             word-wrap: break-word;
-            line-height: 1.5;
+            line-height: 1.55;
+            font-size: 1rem;
         }
         .message.user {
             background-color: #007bff;
@@ -156,10 +117,12 @@
             border-bottom-left-radius: 4px;
         }
         .message .sender {
-            font-size: 0.75rem;
+            font-size: 0.8rem;
             font-weight: bold;
-            margin-bottom: 0.25rem;
-            opacity: 0.8;
+            margin-bottom: 0.3rem;
+            opacity: 0.85;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
         }
         .message .text {
             white-space: pre-wrap;
@@ -245,8 +208,10 @@
             font-size: 1rem;
             resize: none;
             min-height: 48px;
-            max-height: 120px;
+            max-height: 30vh;
             font-family: Arial, sans-serif;
+            line-height: 1.4;
+            overflow-y: auto;
         }
         .btn {
             background-color: #007bff;
@@ -315,6 +280,60 @@
         .btn-success:hover { background-color: #218838; }
         .btn-danger { background-color: #dc3545; }
         .btn-danger:hover { background-color: #c82333; }
+
+        /* Mobile overrides — must come last so they win the cascade against the
+           desktop defaults above. Reclaims vertical space on phones. */
+        @media (max-width: 600px) {
+            .container {
+                padding: 0 0.5rem 0.25rem;
+            }
+            #logo {
+                display: none;
+            }
+            #description {
+                display: none;
+            }
+            h1 {
+                font-size: 1rem;
+                margin: 0.25rem 0;
+                font-weight: 600;
+            }
+            #status {
+                margin: 0;
+                min-height: 0;
+                font-size: 0.85rem;
+            }
+            #status:empty {
+                display: none;
+            }
+            #navDropdown {
+                margin: 0.25rem 0 !important;
+            }
+            #chat-messages {
+                padding: 0.5rem;
+                margin-bottom: 0.5rem;
+            }
+            .message {
+                max-width: 95%;
+                padding: 0.6rem 0.85rem;
+                margin-bottom: 0.6rem;
+                font-size: 1rem;
+                line-height: 1.55;
+            }
+            .message .sender {
+                font-size: 0.85rem;
+            }
+            #chat-input {
+                min-height: 44px;
+                font-size: 16px; /* prevents iOS zoom */
+                padding: 0.6rem;
+                line-height: 1.4;
+            }
+            .btn {
+                padding: 0.6rem 0.9rem;
+                font-size: 1rem;
+            }
+        }
     </style>
 </head>
 <body>
@@ -430,6 +449,7 @@
             if (!text) return;
 
             inputEl.value = '';
+            inputEl.style.height = '';
             appendMessage('You', text, true);
             sendBtn.disabled = true;
             setStatus('');
@@ -549,6 +569,14 @@
                 sendMessage();
             }
         });
+
+        function autosizeInput() {
+            inputEl.style.height = 'auto';
+            const max = Math.round(window.innerHeight * 0.3);
+            inputEl.style.height = Math.min(inputEl.scrollHeight, max) + 'px';
+        }
+        inputEl.addEventListener('input', autosizeInput);
+        window.addEventListener('resize', autosizeInput);
     })();
     </script>
 </body>


### PR DESCRIPTION
## Summary
- The Governor Chat page (`chat.html`) was unusable on mobile — six stacked header rows squeezed the conversation area to roughly half the viewport, and the `@media (max-width: 600px)` overrides were authored *before* the desktop defaults, so same-specificity rules silently shadowed every mobile h1/description/message tweak.
- Moved the `@media` block to the end of `<style>` so mobile rules actually win the cascade.
- On phones (≤600px): hide `#logo` and `#description`, shrink `<h1>` to a slim 1rem banner, hide `#status` when empty. Reclaims ~150px of vertical space.
- Bumped message body to 1rem / 1.55 line-height and sender label from 0.75rem to 0.8rem (uppercase + letter-spacing) for readability on every viewport.
- Auto-grow `#chat-input` up to 30vh as the user types, reset on send. Replaces the fixed 120px max-height that truncated long drafts.

## Verification
Captured iPhone 13 (390×664) and 1280×800 desktop screenshots via Playwright. Mobile messages-panel utilization at default input height: ~52% before → ~74% after; with a 5-line draft in the input, ~52% → ~56% (no longer dominated by chrome). Desktop layout unchanged aside from the deliberate sender-label restyle.

## Test plan
- [ ] On a phone, open `https://dapp.truesight.me/chat.html` (after deploy) and confirm the logo + description are hidden, the title is a slim 1-line banner, and the conversation area takes the majority of the screen.
- [ ] Type a multi-line draft into the input; verify it grows up to ~30% of viewport height and resets after send.
- [ ] Open on desktop (>600px) and confirm the logo, title, description, and chat panel still render in their full form.
- [ ] Send a message end-to-end against `chatbot.truesight.me` to confirm no JS regressions from the textarea autosize listener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)