### PR TITLE
feat(permissions): add Permissions helper + Governor-only Add Contributor page

### DIFF
--- a/batch_qr_generator.html
+++ b/batch_qr_generator.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260426"></script>
+    <script src="./menu.js?v=20260427"></script>
     <script src="./tdg_balance.js"></script>
     
     <style>

--- a/chat.html
+++ b/chat.html
@@ -22,7 +22,7 @@
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
-    <script src="./menu.js?v=20260426"></script>
+    <script src="./menu.js?v=20260427"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/edgar_payload_helper.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>

--- a/create_proposal.html
+++ b/create_proposal.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260426"></script>
+    <script src="./menu.js?v=20260427"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         * {

--- a/create_signature.html
+++ b/create_signature.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
   
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260426"></script>
+  <script src="./menu.js?v=20260427"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/edgar_payload_helper.js"></script>

--- a/governor_contributor_admin.html
+++ b/governor_contributor_admin.html
@@ -1,0 +1,413 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="Governor-only: register a new TrueSight DAO contributor with name and email.">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Add New Contributor (Governor)</title>
+
+  <meta property="og:title" content="Add New Contributor (Governor)">
+  <meta property="og:description" content="Governor-only: register a new TrueSight DAO contributor with name and email.">
+  <meta property="og:image" content="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
+  <meta property="og:url" content="https://truesightdao.github.io/dapp/">
+  <meta property="og:type" content="website">
+
+  <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
+
+  <script src="./routes.js"></script>
+  <script src="./menu.js?v=20260427"></script>
+  <script src="./scripts/dao_members_cache.js"></script>
+  <script src="./scripts/permissions.js"></script>
+
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      margin: 1rem;
+      padding: 1rem;
+      min-height: 100vh;
+      box-sizing: border-box;
+      background-color: #f5f5f5;
+    }
+    .container {
+      max-width: 640px;
+      width: 100%;
+      background-color: white;
+      padding: 1.25rem;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+    h1 {
+      font-size: 1.6rem;
+      color: #333;
+      margin: 0.5rem 0 0.5rem;
+      text-align: center;
+    }
+    #description {
+      font-style: italic;
+      color: #555;
+      line-height: 1.5;
+      margin: 0.6rem 0 1rem;
+      font-size: 0.95rem;
+      text-align: center;
+    }
+    #welcome {
+      font-size: 1rem;
+      font-weight: bold;
+      margin: 0.6rem 0;
+      text-align: center;
+      color: #28a745;
+    }
+    .form-row {
+      margin: 0.9rem 0;
+    }
+    .form-row label {
+      display: block;
+      font-weight: bold;
+      margin-bottom: 0.3rem;
+      color: #333;
+    }
+    .form-row input,
+    .form-row textarea {
+      width: 100%;
+      padding: 0.7rem;
+      font-size: 1rem;
+      box-sizing: border-box;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+    }
+    .form-row textarea {
+      resize: vertical;
+      min-height: 80px;
+      font-family: ui-monospace, SFMono-Regular, monospace;
+      font-size: 0.85rem;
+    }
+    .form-row .hint {
+      font-size: 0.85rem;
+      color: #666;
+      margin-top: 0.3rem;
+    }
+    .dedup {
+      margin-top: 0.4rem;
+      font-size: 0.9rem;
+      min-height: 1.2em;
+    }
+    .dedup.warn {
+      color: #b54708;
+      background: #fff7ed;
+      border: 1px solid #fed7aa;
+      padding: 0.5rem 0.6rem;
+      border-radius: 4px;
+    }
+    .dedup.ok {
+      color: #166534;
+    }
+    button.primary {
+      width: 100%;
+      padding: 0.85rem;
+      font-size: 1rem;
+      font-weight: bold;
+      color: white;
+      background-color: #28a745;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    button.primary[disabled] {
+      background-color: #999;
+      cursor: not-allowed;
+    }
+    #status {
+      margin: 1rem 0;
+      font-weight: bold;
+      min-height: 24px;
+      font-size: 0.95rem;
+      text-align: center;
+    }
+    #status.success { color: #28a745; }
+    #status.error { color: #dc3545; }
+    #backLink {
+      font-size: 0.95rem;
+      color: #007bff;
+      text-decoration: none;
+    }
+    #backLink::before { content: "← "; }
+    .gov-badge {
+      display: inline-block;
+      padding: 0.15rem 0.55rem;
+      background: #e8f5e9;
+      color: #166534;
+      border: 1px solid #86efac;
+      border-radius: 999px;
+      font-size: 0.78rem;
+      font-weight: bold;
+      letter-spacing: 0.02em;
+      margin-left: 0.4rem;
+      vertical-align: middle;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <a id="backLink" href="./index.html">Back to Home</a>
+    <h1>Add New Contributor <span class="gov-badge">Governor</span></h1>
+    <p id="description">
+      Register a new contributor on the TrueSight DAO ledger with their name and email. The new contributor will later self-register their first device public key via <code>[EMAIL VERIFICATION EVENT]</code>; you do not need to enter a public key here.
+    </p>
+
+    <div id="gateContainer">
+      <p id="status">Loading…</p>
+    </div>
+
+    <div id="formContainer" style="display: none;">
+      <div id="welcome"></div>
+
+      <form id="addContributorForm" autocomplete="off">
+        <div class="form-row">
+          <label for="contributorName">Display name <span style="color: #dc3545;">*</span></label>
+          <input type="text" id="contributorName" name="contributorName" required maxlength="120" placeholder="e.g. Jane Smith">
+          <div class="hint">How this person will appear on the contribution ledger and in Telegram Chat Logs.</div>
+          <div class="dedup" id="nameDedup"></div>
+        </div>
+
+        <div class="form-row">
+          <label for="contributorEmail">Email <span style="color: #dc3545;">*</span></label>
+          <input type="email" id="contributorEmail" name="contributorEmail" required maxlength="200" placeholder="e.g. jane@example.com">
+          <div class="hint">Hard-required. The contributor will use this email to self-register their first device public key via <code>[EMAIL VERIFICATION EVENT]</code> later.</div>
+          <div class="dedup" id="emailDedup"></div>
+        </div>
+
+        <div class="form-row">
+          <label for="contributorInitialKey">Initial public key (optional)</label>
+          <textarea id="contributorInitialKey" name="contributorInitialKey" maxlength="3000" placeholder="(leave blank — the contributor will self-register a key via the email-verification flow)"></textarea>
+          <div class="hint">Only paste here if the contributor has already generated a key on their device and shared it with you. Otherwise leave blank.</div>
+        </div>
+
+        <button type="submit" class="primary" id="submitButton">Add contributor</button>
+      </form>
+
+      <p id="status"></p>
+    </div>
+  </div>
+
+  <script>
+    const EDGAR_SUBMIT = (window.Routes && window.Routes.edgar && window.Routes.edgar.submit)
+        || 'https://edgar.truesight.me/dao/submit_contribution';
+
+    const ACTION = 'contributor.add';
+
+    const publicKey = (function () {
+      try { return localStorage.getItem('publicKey') || ''; } catch (_) { return ''; }
+    })();
+    const privateKey = (function () {
+      try { return localStorage.getItem('privateKey') || ''; } catch (_) { return ''; }
+    })();
+
+    function setStatus(msg, kind) {
+      const els = document.querySelectorAll('#status');
+      for (let i = 0; i < els.length; i++) {
+        els[i].textContent = msg || '';
+        els[i].className = kind || '';
+      }
+    }
+
+    function base64ToArrayBuffer(b64) {
+      const bin = atob(b64);
+      const out = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+      return out.buffer;
+    }
+    function arrayBufferToBase64(buf) {
+      return btoa(String.fromCharCode.apply(null, new Uint8Array(buf)));
+    }
+
+    function debounce(fn, ms) {
+      let t = null;
+      return function () {
+        const args = arguments;
+        clearTimeout(t);
+        t = setTimeout(function () { fn.apply(null, args); }, ms);
+      };
+    }
+
+    /**
+     * Pre-flight dedup against dao_members.json. Returns { hit, contributor }
+     * where hit is null on no match, 'name' on display-name match, 'email' on
+     * email match.
+     */
+    function preflightDedup(name, email) {
+      return window.DaoMembersCache.fetchSnapshot().then(function (snapshot) {
+        const list = (snapshot && snapshot.contributors) || [];
+        const lname = (name || '').trim().toLowerCase();
+        const lmail = (email || '').trim().toLowerCase();
+        let nameHit = null;
+        let emailHit = null;
+        for (let i = 0; i < list.length; i++) {
+          const c = list[i] || {};
+          const cname = String(c.name || '').trim().toLowerCase();
+          const cmail = String(c.email || '').trim().toLowerCase();
+          if (lname && cname && cname === lname) nameHit = c;
+          if (lmail && cmail && cmail === lmail) emailHit = c;
+        }
+        return { nameHit: nameHit, emailHit: emailHit };
+      });
+    }
+
+    function renderDedup(elementId, hit, kind) {
+      const el = document.getElementById(elementId);
+      if (!hit) {
+        el.textContent = '';
+        el.className = 'dedup';
+        return;
+      }
+      const keyCount = (hit.public_keys || []).length;
+      el.className = 'dedup warn';
+      if (kind === 'name') {
+        el.innerHTML =
+            'A contributor named <strong>' + (hit.name || '').replace(/</g, '&lt;') +
+            '</strong> already exists' +
+            (hit.email ? ' (' + (hit.email || '').replace(/</g, '&lt;') + ')' : '') +
+            ' with ' + keyCount + ' active key(s). If this is the same person, they may want a new device key — use the email-verification flow instead.';
+      } else if (kind === 'email') {
+        el.innerHTML =
+            '<strong>' + (hit.email || '').replace(/</g, '&lt;') +
+            '</strong> already belongs to <strong>' +
+            (hit.name || '').replace(/</g, '&lt;') + '</strong>. If they need another device key, ask them to use the existing email-verification flow rather than registering a new contributor.';
+      }
+    }
+
+    async function signAndSubmit(plainText) {
+      if (!privateKey) throw new Error('No private key in localStorage. Use Digital Signature Creator first.');
+      const keyObj = await window.crypto.subtle.importKey(
+          'pkcs8',
+          base64ToArrayBuffer(privateKey),
+          { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+          false,
+          ['sign']);
+      const signature = await window.crypto.subtle.sign(
+          'RSASSA-PKCS1-v1_5', keyObj, new TextEncoder().encode(plainText));
+      const requestHash = arrayBufferToBase64(signature);
+      const shareText = plainText +
+          '\n\nMy Digital Signature: ' + publicKey +
+          '\n\nRequest Transaction ID: ' + requestHash +
+          '\n\nThis submission was generated using ' + window.location.href +
+          '\n\nVerify submission here: https://dapp.truesight.me/verify_request.html';
+      const formData = new FormData();
+      formData.append('text', shareText);
+      const resp = await fetch(EDGAR_SUBMIT, { method: 'POST', body: formData });
+      if (!resp.ok) throw new Error(await resp.text());
+      return await resp.json();
+    }
+
+    function buildEventText(name, email, initialKey) {
+      const ts = new Date().toISOString();
+      const lines = [
+        '[CONTRIBUTOR ADD EVENT]',
+        '- Contributor Name: ' + name,
+        '- Contributor Email: ' + email,
+        '- Initial Digital Signature: ' + (initialKey || '(none — contributor will self-register via [EMAIL VERIFICATION EVENT])'),
+        '- Submitted At: ' + ts,
+        '- Submission Source: ' + window.location.href,
+        '--------',
+      ];
+      return lines.join('\n');
+    }
+
+    function attachFormHandlers(checkResult) {
+      document.getElementById('formContainer').style.display = 'block';
+      document.querySelector('#gateContainer').style.display = 'none';
+      const wel = document.getElementById('welcome');
+      const cn = (checkResult.contributor && checkResult.contributor.name) || '(governor)';
+      wel.textContent = 'Welcome, ' + cn + '. Permission verified.';
+
+      const nameInput = document.getElementById('contributorName');
+      const emailInput = document.getElementById('contributorEmail');
+      const keyInput = document.getElementById('contributorInitialKey');
+      const submitBtn = document.getElementById('submitButton');
+      const form = document.getElementById('addContributorForm');
+
+      const runDedup = debounce(function () {
+        preflightDedup(nameInput.value, emailInput.value)
+            .then(function (r) {
+              renderDedup('nameDedup', r.nameHit, 'name');
+              renderDedup('emailDedup', r.emailHit, 'email');
+            })
+            .catch(function (err) {
+              console.error('Dedup pre-flight failed:', err);
+            });
+      }, 300);
+
+      nameInput.addEventListener('input', runDedup);
+      emailInput.addEventListener('input', runDedup);
+
+      form.addEventListener('submit', async function (ev) {
+        ev.preventDefault();
+        const name = nameInput.value.trim();
+        const email = emailInput.value.trim();
+        const initialKey = keyInput.value.trim();
+        if (!name || !email) {
+          setStatus('Display name and email are both required.', 'error');
+          return;
+        }
+        // Hard re-check the dedup synchronously before submit; server will also reject on conflict.
+        let dedup;
+        try {
+          dedup = await preflightDedup(name, email);
+        } catch (err) {
+          setStatus('Could not pre-flight dedup: ' + err.message + '. Submitting anyway — server will re-check.', '');
+        }
+        if (dedup && (dedup.nameHit || dedup.emailHit)) {
+          if (!confirm('A possible duplicate was detected. Submit anyway? Server will reject if it confirms a conflict.')) {
+            return;
+          }
+        }
+        submitBtn.disabled = true;
+        setStatus('Signing and submitting…', '');
+        try {
+          const text = buildEventText(name, email, initialKey);
+          const result = await signAndSubmit(text);
+          setStatus(
+              'Submitted. Edgar response: ' + JSON.stringify(result) +
+              '. The contributor row should appear on dao_members.json after the next publisher run (~30 min, or manual refresh).',
+              'success');
+          form.reset();
+          document.getElementById('nameDedup').textContent = '';
+          document.getElementById('emailDedup').textContent = '';
+        } catch (err) {
+          console.error('Submit failed:', err);
+          setStatus('Submission failed: ' + err.message, 'error');
+        } finally {
+          submitBtn.disabled = false;
+        }
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+      if (!publicKey) {
+        document.getElementById('gateContainer').innerHTML =
+            '<div style="max-width: 600px; margin: 1.5rem auto; padding: 1.25rem; ' +
+            'background: #fff5f5; border: 1px solid #f5c2c7; border-radius: 8px; color: #842029;">' +
+            '<h2 style="margin: 0 0 0.5rem 0;">Sign in first</h2>' +
+            '<p style="margin: 0;">No digital signature found in your browser. Please use ' +
+            '<a href="./create_signature.html">the Digital Signature Creator</a> first to set up your identity, ' +
+            'then return here.</p></div>';
+        return;
+      }
+      window.Permissions.requireRole({
+        action: ACTION,
+        publicKey: publicKey,
+        denyContainerId: 'gateContainer',
+        onAllowed: attachFormHandlers,
+        onDenied: function () {
+          // Permissions.requireRole already rendered the denied UI.
+        },
+      }).catch(function (err) {
+        console.error('Permission check failed:', err);
+        setStatus('Permission check failed: ' + err.message, 'error');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <meta property="og:type" content="website">
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
-  <script src="./menu.js?v=20260426"></script>
+  <script src="./menu.js?v=20260427"></script>
   <script src="./tdg_balance.js"></script>
 
   <title>TrueSight DAO - Community Collaboration Tools</title>

--- a/menu.js
+++ b/menu.js
@@ -30,7 +30,8 @@
     { title: 'Verify Signed Request', url: './verify_request.html', section: 'Identity & Governance' },
     { title: 'DAO Proposal Management', url: './view_open_proposals.html', section: 'Identity & Governance' },
     { title: 'Create Proposal', url: './create_proposal.html', section: 'Identity & Governance' },
-    { title: 'Review & Vote on Proposal', url: './review_proposal.html', section: 'Identity & Governance' }
+    { title: 'Review & Vote on Proposal', url: './review_proposal.html', section: 'Identity & Governance' },
+    { title: 'Add New Contributor (Governor)', url: './governor_contributor_admin.html', section: 'Identity & Governance' }
   ];
 
   document.addEventListener('DOMContentLoaded', function() {

--- a/notarize.html
+++ b/notarize.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260426"></script>
+  <script src="./menu.js?v=20260427"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/register_farm.html
+++ b/register_farm.html
@@ -17,7 +17,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260426"></script>
+  <script src="./menu.js?v=20260427"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/repackaging_planner.html
+++ b/repackaging_planner.html
@@ -11,7 +11,7 @@
   <meta property="og:type" content="website">
   <link rel="icon" type="image/png" href="https://raw.githubusercontent.com/TrueSightDAO/.github/main/assets/20240612_truesight_dao_logo_square.png">
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260426"></script>
+  <script src="./menu.js?v=20260427"></script>
   <script src="./tdg_balance.js"></script>
   <title>Repackaging Planner - TrueSight DAO</title>
   <style>

--- a/report_capital_injection.html
+++ b/report_capital_injection.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260426"></script>
+    <script src="./menu.js?v=20260427"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/report_contribution.html
+++ b/report_contribution.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260426"></script>
+    <script src="./menu.js?v=20260427"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/report_dao_expenses.html
+++ b/report_dao_expenses.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260426"></script>
+    <script src="./menu.js?v=20260427"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./expense-form-utils.js"></script>
     <script src="./js/treasury_cache.js"></script>

--- a/report_inventory_movement.html
+++ b/report_inventory_movement.html
@@ -15,8 +15,10 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260426"></script>
+    <script src="./menu.js?v=20260427"></script>
     <script src="./tdg_balance.js"></script>
+    <script src="./scripts/dao_members_cache.js"></script>
+    <script src="./scripts/permissions.js"></script>
     
     <style>
         body {
@@ -379,10 +381,16 @@
                         <div id="recipientAutocompleteList" style="max-height: 200px; overflow-y: auto;"></div>
                     </div>
                 </div>
-                <label for="newRecipientInput" style="margin-top: 0.5rem; font-size: 0.9rem; color: #666;">Or enter a new recipient name:</label>
-                <input type="text" id="newRecipientInput" placeholder="Type new recipient name here..." style="display: none;">
-                <div id="recipientInputInfo" style="font-size: 0.85rem; color: #666; margin-top: 0.3rem; display: none;">
-                    New recipients will be automatically added to the Contributors list.
+                <!-- Governor-only: ability to type a new recipient name (which auto-creates a Contributors row server-side).
+                     The wrapper #newRecipientGovernorOnly stays display:none until permissions.js confirms the signed-in
+                     identity has the `contributor.add` action; non-governors never see this affordance. The server still
+                     enforces this independently — see process_movement_telegram_logs.gs (movementStatus === 'NEW' gate). -->
+                <div id="newRecipientGovernorOnly" style="display: none;">
+                    <label for="newRecipientInput" style="margin-top: 0.5rem; font-size: 0.9rem; color: #666;">Or enter a new recipient name (Governor only):</label>
+                    <input type="text" id="newRecipientInput" placeholder="Type new recipient name here..." style="display: none;">
+                    <div id="recipientInputInfo" style="font-size: 0.85rem; color: #666; margin-top: 0.3rem; display: none;">
+                        New recipients will be automatically added to the Contributors list. Prefer the dedicated <a href="./governor_contributor_admin.html">Add New Contributor</a> page when an email is available — it captures email so the contributor can self-register a device key later.
+                    </div>
                 </div>
             </div>
             <div class="form-row">
@@ -2929,6 +2937,28 @@
                 if (reportButton) {
                     reportButton.style.display = 'none';
                 }
+            }
+
+            // Governor-only gate for the "type a brand-new recipient name" affordance.
+            // Hidden by default in the markup (#newRecipientGovernorOnly display:none).
+            // We only reveal it after permissions.js confirms the signed-in identity has
+            // contributor.add. Server still enforces the rule (see process_movement_telegram_logs.gs
+            // movementStatus === 'NEW' gate), so this is purely a UX nudge to keep
+            // non-governors from seeing an affordance they cannot use.
+            try {
+                const pk = localStorage.getItem('publicKey') || '';
+                if (pk && window.Permissions) {
+                    window.Permissions.check('contributor.add', pk).then(function (r) {
+                        if (r.allowed) {
+                            const wrap = document.getElementById('newRecipientGovernorOnly');
+                            if (wrap) wrap.style.display = '';
+                        }
+                    }).catch(function (err) {
+                        console.warn('Permissions.check (contributor.add) failed:', err);
+                    });
+                }
+            } catch (err) {
+                console.warn('Governor-gate setup failed:', err);
             }
         });
     </script>

--- a/report_sales.html
+++ b/report_sales.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260426"></script>
+    <script src="./menu.js?v=20260427"></script>
     <script src="./tdg_balance.js"></script>
     
     <style>

--- a/report_tree_planting.html
+++ b/report_tree_planting.html
@@ -17,7 +17,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260426"></script>
+  <script src="./menu.js?v=20260427"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/restock_recommender.html
+++ b/restock_recommender.html
@@ -24,7 +24,7 @@
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260426"></script>
+    <script src="./menu.js?v=20260427"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         body {

--- a/review_proposal.html
+++ b/review_proposal.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260426"></script>
+    <script src="./menu.js?v=20260427"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         * {

--- a/scanner.html
+++ b/scanner.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260426"></script>
+    <script src="./menu.js?v=20260427"></script>
     <script src="./tdg_balance.js"></script>
     
     <style>

--- a/scripts/permissions.js
+++ b/scripts/permissions.js
@@ -1,0 +1,185 @@
+/**
+ * Permissions — client-side gate for the TrueSight DAO DApp permission model.
+ *
+ * Loads `permissions.json` (the action -> required_roles map; PR-reviewed source
+ * of truth) from treasury-cache and resolves `(action, public_key) -> { allowed,
+ * contributor, missing_roles }` by joining against `dao_members.json` (loaded
+ * via the existing window.DaoMembersCache helper).
+ *
+ *   Source files:
+ *     https://raw.githubusercontent.com/TrueSightDAO/treasury-cache/main/permissions.json
+ *     https://raw.githubusercontent.com/TrueSightDAO/treasury-cache/main/dao_members.json
+ *
+ * IMPORTANT: this is the UX gate only. Every privileged endpoint (Edgar,
+ * tokenomics GAS) MUST also enforce the same rule server-side; the client
+ * gate stops accidental misuse, not motivated bypass.
+ *
+ * Exposes:
+ *   window.Permissions.fetchManifest() -> Promise<manifest JSON>
+ *   window.Permissions.check(action, publicKey)
+ *       -> Promise<{ allowed, contributor, missing_roles, action_def, reason }>
+ *   window.Permissions.requireRole(opts)
+ *       opts: { action, publicKey, denyContainerId, onAllowed, onDenied }
+ *       Renders the explicit permission-denied UI inside denyContainerId
+ *       (or document.body if not specified) when not allowed; otherwise
+ *       calls onAllowed(checkResult).
+ *   window.Permissions.invalidate() -> drop cached manifest; next call refetches.
+ *
+ * Convention note: roles are case-sensitive lowercase strings ("governor",
+ * "member", "operator", "custodian"). dao_members_cache_publisher emits the
+ * Governors-tab join as ["governor", "member"]; see treasury-cache README
+ * `dao_members.json` schema (v3+) for the source of truth.
+ */
+(function (global) {
+  const DEFAULT_URL =
+      'https://raw.githubusercontent.com/TrueSightDAO/treasury-cache/main/permissions.json';
+
+  let cachedPromise = null;
+  let cachedUrl = null;
+
+  function resolveUrl() {
+    return (global.Routes && global.Routes.permissions) || DEFAULT_URL;
+  }
+
+  function fetchManifest() {
+    const url = resolveUrl();
+    if (cachedPromise && cachedUrl === url) return cachedPromise;
+    cachedUrl = url;
+    cachedPromise = global.fetch(url, { cache: 'no-cache' }).then(function (resp) {
+      if (!resp.ok) {
+        cachedPromise = null;
+        throw new Error('permissions.json HTTP ' + resp.status);
+      }
+      return resp.json();
+    }).catch(function (err) {
+      cachedPromise = null;
+      throw err;
+    });
+    return cachedPromise;
+  }
+
+  function actionDef(manifest, action) {
+    if (!manifest || !manifest.actions) return null;
+    return manifest.actions[action] || null;
+  }
+
+  function rolesIntersect(have, required) {
+    if (!Array.isArray(have) || !Array.isArray(required)) return false;
+    for (let i = 0; i < required.length; i++) {
+      if (have.indexOf(required[i]) >= 0) return true;
+    }
+    return false;
+  }
+
+  function check(action, publicKey) {
+    if (!global.DaoMembersCache) {
+      return Promise.reject(new Error(
+          'Permissions.check requires DaoMembersCache (load scripts/dao_members_cache.js first)'));
+    }
+    return Promise.all([
+      fetchManifest(),
+      global.DaoMembersCache.findByPublicKey(publicKey),
+    ]).then(function (results) {
+      const manifest = results[0];
+      const lookup = results[1];
+      const def = actionDef(manifest, action);
+      if (!def) {
+        return {
+          allowed: false,
+          contributor: lookup.contributor,
+          missing_roles: [],
+          action_def: null,
+          reason:
+              'Unknown action ' + JSON.stringify(action) +
+              '. The action is not declared in permissions.json — it must be added there ' +
+              'before the DApp can gate it.',
+        };
+      }
+      const required = def.required_roles || [];
+      if (!lookup.contributor) {
+        return {
+          allowed: false,
+          contributor: null,
+          missing_roles: required,
+          action_def: def,
+          reason: 'Signed-in public key is not a registered DAO contributor.',
+        };
+      }
+      const have = (lookup.contributor.roles && lookup.contributor.roles.slice()) || [];
+      const ok = rolesIntersect(have, required);
+      return {
+        allowed: ok,
+        contributor: lookup.contributor,
+        missing_roles: ok ? [] : required.filter(function (r) { return have.indexOf(r) < 0; }),
+        action_def: def,
+        reason: ok
+            ? null
+            : 'Permission denied — this action is restricted to roles: ' +
+              required.join(', ') + '. Your roles: ' + (have.join(', ') || '(none)') + '.',
+      };
+    });
+  }
+
+  function renderDenied(opts, checkResult) {
+    const containerId = opts && opts.denyContainerId;
+    const target = containerId ? document.getElementById(containerId) : document.body;
+    if (!target) return;
+    const def = checkResult.action_def || {};
+    const action = (opts && opts.action) || '(unknown)';
+    const required = (def.required_roles || []).join(', ') || '(undeclared)';
+    const have = (checkResult.contributor && checkResult.contributor.roles &&
+        checkResult.contributor.roles.join(', ')) || '(none)';
+    const description = def.description || '';
+    target.innerHTML =
+        '<div class="permission-denied" style="' +
+        'max-width: 600px; margin: 2rem auto; padding: 1.5rem; ' +
+        'background: #fff5f5; border: 1px solid #f5c2c7; border-radius: 8px; ' +
+        'color: #842029; font-family: Arial, sans-serif;">' +
+        '<h2 style="margin: 0 0 0.5rem 0; color: #842029;">Permission denied</h2>' +
+        '<p style="margin: 0 0 1rem 0;">This action is restricted to <strong>' +
+        required + '</strong>.</p>' +
+        (description
+            ? '<p style="margin: 0 0 1rem 0; font-size: 0.95rem; color: #555;">' +
+              '<em>' + description.replace(/</g, '&lt;') + '</em></p>'
+            : '') +
+        '<p style="margin: 0 0 0.5rem 0; font-size: 0.9rem;">' +
+        '<strong>Action:</strong> ' + action + '<br>' +
+        '<strong>Your roles:</strong> ' + have + '</p>' +
+        '<p style="margin: 1rem 0 0 0; font-size: 0.9rem;">' +
+        'If you believe this is incorrect, contact a Governor. The Governor list ' +
+        'rotates 4×/year on the equinoxes/solstices; current members are visible on ' +
+        '<a href="https://docs.google.com/spreadsheets/d/1GE7PUq-UT6x2rBN-Q2ksogbWpgyuh2SaxJyG_uEK6PU/edit?gid=842148543" target="_blank">' +
+        'the Governors tab</a> on the Main Ledger.</p>' +
+        '<p style="margin: 1rem 0 0 0;"><a href="./index.html" style="color: #0d6efd;">' +
+        '← Back to Home</a></p>' +
+        '</div>';
+  }
+
+  function requireRole(opts) {
+    if (!opts || !opts.action) {
+      return Promise.reject(new Error('Permissions.requireRole requires opts.action'));
+    }
+    return check(opts.action, opts.publicKey).then(function (result) {
+      if (result.allowed) {
+        if (typeof opts.onAllowed === 'function') opts.onAllowed(result);
+        return result;
+      }
+      renderDenied(opts, result);
+      if (typeof opts.onDenied === 'function') opts.onDenied(result);
+      return result;
+    });
+  }
+
+  function invalidate() {
+    cachedPromise = null;
+    cachedUrl = null;
+  }
+
+  global.Permissions = {
+    DEFAULT_URL: DEFAULT_URL,
+    fetchManifest: fetchManifest,
+    check: check,
+    requireRole: requireRole,
+    invalidate: invalidate,
+  };
+})(window);

--- a/service-worker.js
+++ b/service-worker.js
@@ -39,12 +39,15 @@ const URLS_TO_CACHE = [
   './submit_feedback.html',
   './verify_request.html',
   './withdraw_voting_rights.html',
+  './governor_contributor_admin.html',
   // Scripts
-  './menu.js?v=20260426',
+  './menu.js?v=20260427',
   './routes.js',
   './service-worker.js',
   './js/treasury_cache.js',
   './js/dapp_footer_links.js?v=1',
+  './scripts/dao_members_cache.js',
+  './scripts/permissions.js',
   // External libraries
   'https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.min.js',
   // Assets

--- a/shipping_planner.html
+++ b/shipping_planner.html
@@ -53,7 +53,7 @@
     </script>
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCS5tz9sp9mWG6d_glVO19UUk8ZyZ3LdbQ&callback=onGoogleMapsReady&v=weekly&loading=async&libraries=places"></script>
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260426"></script>
+    <script src="./menu.js?v=20260427"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./js/treasury_cache.js"></script>
     

--- a/store_interaction_history.html
+++ b/store_interaction_history.html
@@ -20,7 +20,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260426"></script>
+    <script src="./menu.js?v=20260427"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/stores_by_status.html
+++ b/stores_by_status.html
@@ -15,7 +15,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260426"></script>
+    <script src="./menu.js?v=20260427"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/stores_nearby.html
+++ b/stores_nearby.html
@@ -45,7 +45,7 @@
     </script>
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBWmnvjWeYIEju0JLbfN-Z09k1HEsXzWe4&callback=onGoogleMapsReady&v=weekly&loading=async&libraries=places"></script>
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260426"></script>
+    <script src="./menu.js?v=20260427"></script>
     <script src="./tdg_balance.js"></script>
     
     <!-- Leaflet.js for maps (no API key required) -->

--- a/submit_feedback.html
+++ b/submit_feedback.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260426"></script>
+    <script src="./menu.js?v=20260427"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/update_qr_code.html
+++ b/update_qr_code.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260426"></script>
+    <script src="./menu.js?v=20260427"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/edgar_payload_helper.js"></script>
 

--- a/verify_request.html
+++ b/verify_request.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260426"></script>
+  <script src="./menu.js?v=20260427"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/view_inventory_holdings.html
+++ b/view_inventory_holdings.html
@@ -14,7 +14,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260426"></script>
+    <script src="./menu.js?v=20260427"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./js/treasury_cache.js"></script>
 

--- a/view_open_proposals.html
+++ b/view_open_proposals.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260426"></script>
+    <script src="./menu.js?v=20260427"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/withdraw_voting_rights.html
+++ b/withdraw_voting_rights.html
@@ -15,7 +15,7 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260426"></script>
+  <script src="./menu.js?v=20260427"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {


### PR DESCRIPTION
## Summary

Step 3 of the DApp permission rework. Builds the client-side gate that turns the just-merged data foundations (`treasury-cache/permissions.json`, `dao_members.json` schema v3 with `roles` + `email`) into actual UI behavior.

| Change | Purpose |
|---|---|
| **NEW** `scripts/permissions.js` | Tiny helper: loads `permissions.json` from treasury-cache + joins against `DaoMembersCache` to resolve `(action, public_key) → { allowed, contributor, missing_roles, reason }`. Exposes `Permissions.requireRole(opts)` which renders the explicit "Permission denied — restricted to Governors" UI verbatim. |
| **NEW** `governor_contributor_admin.html` | Dedicated governor-only page. Form captures **display name + email** (both hard-required) + optional initial public key. Pre-flight dedup as user types — warns inline if name OR email already belongs to an active contributor. On submit, signs `[CONTRIBUTOR ADD EVENT]` payload and POSTs to Edgar. |
| **EDIT** `report_inventory_movement.html` | Gates the "Or enter a new recipient name" affordance behind `contributor.add`. Non-governors no longer see the input. Server-side enforcement landed in TrueSightDAO/tokenomics PR #248. |
| **EDIT** `menu.js` (+ cache-busting sweep) | Adds "Add New Contributor (Governor)" under Identity & Governance. Bumps `?v=20260427` across all 27 HTML pages per the menu.js convention. |
| **EDIT** `service-worker.js` | New page + scripts added to `URLS_TO_CACHE`. |

## Roadmap context

| Step | Status |
|---|---|
| 1. dao_members.json schema v3 (roles + email) | ✅ [tokenomics #247](https://github.com/TrueSightDAO/tokenomics/pull/247) merged + deployed |
| 2. permissions.json (action → roles map) | ✅ [treasury-cache #3](https://github.com/TrueSightDAO/treasury-cache/pull/3) merged |
| 2b. Edgar inventory auto-add gate | ✅ [tokenomics #248](https://github.com/TrueSightDAO/tokenomics/pull/248) merged + deployed |
| **3. permissions.js + governor_contributor_admin.html** | **this PR** |
| 4. Edgar `[CONTRIBUTOR ADD EVENT]` handler | next (server enforcement + dedup 409) |
| 5. Inline "+ add new contributor" flow on `report_contribution.html` | follow-up |

## Important caveat

Until step 4 ships, submitting from `governor_contributor_admin.html` will succeed at signing + posting to Edgar (the Telegram Chat Logs row gets written), but **no Contributors sheet row gets created** because there's no event handler yet. The form will show "Submitted. Edgar response: ..." and the operator can verify the chat log appeared. That's intentional for the stepwise rollout — UX testing first, server enforcement next.

## Permission denied UX

When a non-governor opens `governor_contributor_admin.html`:
- The form does NOT render
- Instead, an explicit message appears citing the required role(s), the current actor's role(s), the action name, the action description, and a link to the Governors tab on the Main Ledger so the user knows where to ask for elevation
- A "← Back to Home" link is also rendered

When a non-governor visits `report_inventory_movement.html`, the dropdown of existing recipients is unchanged but the "type a brand-new recipient name" input is hidden entirely. They simply don't see the affordance.

Server-side enforcement is independent of these gates — anyone hitting Edgar directly will be rejected by the inventory handler (PR #248).

## Test plan

- [ ] Sign in as a governor (Gary). Open `/governor_contributor_admin.html` → form renders. Type a name that exists → warning appears. Type a new name + email → submit. Verify a Telegram Chat Log row appeared with `[CONTRIBUTOR ADD EVENT]`.
- [ ] Sign in as a non-governor (any other contributor). Open `/governor_contributor_admin.html` → "Permission denied" page renders.
- [ ] Sign in as a governor. Open `/report_inventory_movement.html` → "Or enter a new recipient name (Governor only)" appears under the recipient combobox.
- [ ] Sign in as non-governor on the same page → no new-recipient input visible.
- [ ] Hard-refresh confirms service worker re-cached the new files.

## Follow-ups

- **Step 4** (Edgar handler) — separate PR. Closes the loop so submissions actually create Contributors rows.
- **Step 5** (`report_contribution.html` inline flow) — separate PR. Adds "+ add new contributor" inline on the contribution submission form, governor-gated, posting two writes (`contributor.add` then `contribution.submit_for_other`).
- **Operator / custodian roles** — deferred until Project Zero / channel onboarding makes them real (already documented in `permissions.json` `deferred_actions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)