### PR TITLE
fix(dapp): match page conventions on governor admin + new 'Governor only' menu section

### DIFF
--- a/batch_qr_generator.html
+++ b/batch_qr_generator.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260427"></script>
+    <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
     
     <style>

--- a/chat.html
+++ b/chat.html
@@ -22,7 +22,7 @@
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
-    <script src="./menu.js?v=20260427"></script>
+    <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/edgar_payload_helper.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>

--- a/create_proposal.html
+++ b/create_proposal.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260427"></script>
+    <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         * {

--- a/create_signature.html
+++ b/create_signature.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
   
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260427"></script>
+  <script src="./menu.js?v=20260428"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/edgar_payload_helper.js"></script>

--- a/governor_contributor_admin.html
+++ b/governor_contributor_admin.html
@@ -15,7 +15,8 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260427"></script>
+  <script src="./menu.js?v=20260428"></script>
+  <script src="./tdg_balance.js"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./scripts/permissions.js"></script>
 
@@ -54,15 +55,24 @@
       text-align: center;
     }
     #welcome {
-      font-size: 1rem;
+      font-size: 1.1rem;
       font-weight: bold;
       margin: 0.6rem 0;
       text-align: center;
       color: #28a745;
+      display: none;
     }
-    .form-row {
-      margin: 0.9rem 0;
+    #status {
+      margin: 1rem 0;
+      font-weight: bold;
+      min-height: 24px;
+      font-size: 0.95rem;
+      text-align: center;
     }
+    #status.success { color: #28a745; }
+    #status.error { color: #dc3545; }
+    #status.loading { color: #555; }
+    .form-row { margin: 0.9rem 0; }
     .form-row label {
       display: block;
       font-weight: bold;
@@ -101,9 +111,6 @@
       padding: 0.5rem 0.6rem;
       border-radius: 4px;
     }
-    .dedup.ok {
-      color: #166534;
-    }
     button.primary {
       width: 100%;
       padding: 0.85rem;
@@ -119,21 +126,6 @@
       background-color: #999;
       cursor: not-allowed;
     }
-    #status {
-      margin: 1rem 0;
-      font-weight: bold;
-      min-height: 24px;
-      font-size: 0.95rem;
-      text-align: center;
-    }
-    #status.success { color: #28a745; }
-    #status.error { color: #dc3545; }
-    #backLink {
-      font-size: 0.95rem;
-      color: #007bff;
-      text-decoration: none;
-    }
-    #backLink::before { content: "← "; }
     .gov-badge {
       display: inline-block;
       padding: 0.15rem 0.55rem;
@@ -147,23 +139,34 @@
       margin-left: 0.4rem;
       vertical-align: middle;
     }
+    @keyframes fadeIn {
+      from { opacity: 0; }
+      to   { opacity: 1; }
+    }
+    .fade-in { animation: fadeIn 0.3s ease-in; }
   </style>
 </head>
 <body>
+  <div id="navDropdown" style="margin:1rem 0; text-align:center;"></div>
+  <div id="tdgBalanceBadge"></div>
+  <div id="google_translate_element" style="text-align: right; margin: 1rem;"></div>
   <div class="container">
-    <a id="backLink" href="./index.html">Back to Home</a>
-    <h1>Add New Contributor <span class="gov-badge">Governor</span></h1>
-    <p id="description">
-      Register a new contributor on the TrueSight DAO ledger with their name and email. The new contributor will later self-register their first device public key via <code>[EMAIL VERIFICATION EVENT]</code>; you do not need to enter a public key here.
-    </p>
 
-    <div id="gateContainer">
-      <p id="status">Loading…</p>
+    <div style="text-align: center;">
+      <img id="logo" height="200px" src="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true" alt="TrueSightDAO Logo"/>
     </div>
 
-    <div id="formContainer" style="display: none;">
-      <div id="welcome"></div>
+    <h1>Add New Contributor <span class="gov-badge">Governor</span></h1>
+    <p id="description" class="fade-in">
+      Register a new contributor on the TrueSight DAO ledger with their name and email. The new contributor will later self-register their first device public key via the email-verification flow; you do not need to enter a public key here.
+    </p>
 
+    <div id="welcome"></div>
+    <p id="status" class="loading fade-in" aria-live="polite">Verifying your digital signature&hellip;</p>
+
+    <div id="gateContainer"></div>
+
+    <div id="formContainer" style="display: none;">
       <form id="addContributorForm" autocomplete="off">
         <div class="form-row">
           <label for="contributorName">Display name <span style="color: #dc3545;">*</span></label>
@@ -175,7 +178,7 @@
         <div class="form-row">
           <label for="contributorEmail">Email <span style="color: #dc3545;">*</span></label>
           <input type="email" id="contributorEmail" name="contributorEmail" required maxlength="200" placeholder="e.g. jane@example.com">
-          <div class="hint">Hard-required. The contributor will use this email to self-register their first device public key via <code>[EMAIL VERIFICATION EVENT]</code> later.</div>
+          <div class="hint">Hard-required. The contributor will use this email to self-register their first device public key later.</div>
           <div class="dedup" id="emailDedup"></div>
         </div>
 
@@ -187,8 +190,6 @@
 
         <button type="submit" class="primary" id="submitButton">Add contributor</button>
       </form>
-
-      <p id="status"></p>
     </div>
   </div>
 
@@ -205,12 +206,17 @@
       try { return localStorage.getItem('privateKey') || ''; } catch (_) { return ''; }
     })();
 
+    const statusEl = document.getElementById('status');
+    const welcomeEl = document.getElementById('welcome');
+
     function setStatus(msg, kind) {
-      const els = document.querySelectorAll('#status');
-      for (let i = 0; i < els.length; i++) {
-        els[i].textContent = msg || '';
-        els[i].className = kind || '';
-      }
+      statusEl.textContent = msg || '';
+      statusEl.className = (kind || '') + ' fade-in';
+    }
+
+    function showWelcome(name) {
+      welcomeEl.textContent = 'Welcome back, ' + name + '!';
+      welcomeEl.style.display = 'block';
     }
 
     function base64ToArrayBuffer(b64) {
@@ -233,9 +239,8 @@
     }
 
     /**
-     * Pre-flight dedup against dao_members.json. Returns { hit, contributor }
-     * where hit is null on no match, 'name' on display-name match, 'email' on
-     * email match.
+     * Pre-flight dedup against dao_members.json (cached). Returns
+     * { nameHit, emailHit }; each is the matching contributor object or null.
      */
     function preflightDedup(name, email) {
       return window.DaoMembersCache.fetchSnapshot().then(function (snapshot) {
@@ -269,7 +274,7 @@
             'A contributor named <strong>' + (hit.name || '').replace(/</g, '&lt;') +
             '</strong> already exists' +
             (hit.email ? ' (' + (hit.email || '').replace(/</g, '&lt;') + ')' : '') +
-            ' with ' + keyCount + ' active key(s). If this is the same person, they may want a new device key — use the email-verification flow instead.';
+            ' with ' + keyCount + ' active key(s). If this is the same person, they may want a new device key &mdash; use the email-verification flow instead.';
       } else if (kind === 'email') {
         el.innerHTML =
             '<strong>' + (hit.email || '').replace(/</g, '&lt;') +
@@ -307,7 +312,7 @@
         '[CONTRIBUTOR ADD EVENT]',
         '- Contributor Name: ' + name,
         '- Contributor Email: ' + email,
-        '- Initial Digital Signature: ' + (initialKey || '(none — contributor will self-register via [EMAIL VERIFICATION EVENT])'),
+        '- Initial Digital Signature: ' + (initialKey || '(none — contributor will self-register via the email-verification flow)'),
         '- Submitted At: ' + ts,
         '- Submission Source: ' + window.location.href,
         '--------',
@@ -315,12 +320,8 @@
       return lines.join('\n');
     }
 
-    function attachFormHandlers(checkResult) {
+    function attachFormHandlers() {
       document.getElementById('formContainer').style.display = 'block';
-      document.querySelector('#gateContainer').style.display = 'none';
-      const wel = document.getElementById('welcome');
-      const cn = (checkResult.contributor && checkResult.contributor.name) || '(governor)';
-      wel.textContent = 'Welcome, ' + cn + '. Permission verified.';
 
       const nameInput = document.getElementById('contributorName');
       const emailInput = document.getElementById('contributorEmail');
@@ -351,7 +352,6 @@
           setStatus('Display name and email are both required.', 'error');
           return;
         }
-        // Hard re-check the dedup synchronously before submit; server will also reject on conflict.
         let dedup;
         try {
           dedup = await preflightDedup(name, email);
@@ -364,7 +364,7 @@
           }
         }
         submitBtn.disabled = true;
-        setStatus('Signing and submitting…', '');
+        setStatus('Signing and submitting…', 'loading');
         try {
           const text = buildEventText(name, email, initialKey);
           const result = await signAndSubmit(text);
@@ -386,6 +386,7 @@
 
     document.addEventListener('DOMContentLoaded', function () {
       if (!publicKey) {
+        setStatus('', '');
         document.getElementById('gateContainer').innerHTML =
             '<div style="max-width: 600px; margin: 1.5rem auto; padding: 1.25rem; ' +
             'background: #fff5f5; border: 1px solid #f5c2c7; border-radius: 8px; color: #842029;">' +
@@ -395,19 +396,40 @@
             'then return here.</p></div>';
         return;
       }
-      window.Permissions.requireRole({
-        action: ACTION,
-        publicKey: publicKey,
-        denyContainerId: 'gateContainer',
-        onAllowed: attachFormHandlers,
-        onDenied: function () {
-          // Permissions.requireRole already rendered the denied UI.
-        },
+
+      // Identity check via the cached dao_members.json (CDN-fast, no GAS round-trip).
+      // Then run the role gate. Both reuse a single fetched snapshot.
+      window.DaoMembersCache.findByPublicKey(publicKey).then(function (lookup) {
+        if (!lookup.contributor) {
+          setStatus('', '');
+          document.getElementById('gateContainer').innerHTML =
+              '<div style="max-width: 600px; margin: 1.5rem auto; padding: 1.25rem; ' +
+              'background: #fff5f5; border: 1px solid #f5c2c7; border-radius: 8px; color: #842029;">' +
+              '<h2 style="margin: 0 0 0.5rem 0;">Signature not registered</h2>' +
+              '<p style="margin: 0;">Your digital signature is not yet registered on the DAO ledger. Use ' +
+              '<a href="./create_signature.html">the Digital Signature Creator</a> to register it, then return here.</p></div>';
+          return null;
+        }
+        showWelcome(lookup.contributor.name || '(contributor)');
+        return window.Permissions.requireRole({
+          action: ACTION,
+          publicKey: publicKey,
+          denyContainerId: 'gateContainer',
+          onAllowed: function () {
+            setStatus('Permission verified. You may add a new contributor below.', 'success');
+            attachFormHandlers();
+          },
+          onDenied: function () {
+            setStatus('', '');
+            // Permissions.requireRole already rendered the denied UI in #gateContainer.
+          },
+        });
       }).catch(function (err) {
-        console.error('Permission check failed:', err);
-        setStatus('Permission check failed: ' + err.message, 'error');
+        console.error('Identity / permission check failed:', err);
+        setStatus('Could not verify your signature: ' + err.message, 'error');
       });
     });
   </script>
+  <script src="./js/dapp_footer_links.js?v=1"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <meta property="og:type" content="website">
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
-  <script src="./menu.js?v=20260427"></script>
+  <script src="./menu.js?v=20260428"></script>
   <script src="./tdg_balance.js"></script>
 
   <title>TrueSight DAO - Community Collaboration Tools</title>

--- a/menu.js
+++ b/menu.js
@@ -5,7 +5,8 @@
 (function() {
   window.menuItems = [
     { title: 'Home', url: './index.html', section: '' },
-    { title: 'Governor Chat', url: './chat.html', section: '' },
+    { title: 'Governor Chat', url: './chat.html', section: 'Governor only' },
+    { title: 'Add New Contributor', url: './governor_contributor_admin.html', section: 'Governor only' },
     { title: 'DAO Contribution Reporter', url: './report_contribution.html', section: 'Community Contributions' },
     { title: 'Content Feedback Submission', url: './submit_feedback.html', section: 'Community Contributions' },
     { title: 'Capital Injection Reporter', url: './report_capital_injection.html', section: 'Inventory & ledger' },
@@ -30,8 +31,7 @@
     { title: 'Verify Signed Request', url: './verify_request.html', section: 'Identity & Governance' },
     { title: 'DAO Proposal Management', url: './view_open_proposals.html', section: 'Identity & Governance' },
     { title: 'Create Proposal', url: './create_proposal.html', section: 'Identity & Governance' },
-    { title: 'Review & Vote on Proposal', url: './review_proposal.html', section: 'Identity & Governance' },
-    { title: 'Add New Contributor (Governor)', url: './governor_contributor_admin.html', section: 'Identity & Governance' }
+    { title: 'Review & Vote on Proposal', url: './review_proposal.html', section: 'Identity & Governance' }
   ];
 
   document.addEventListener('DOMContentLoaded', function() {

--- a/notarize.html
+++ b/notarize.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260427"></script>
+  <script src="./menu.js?v=20260428"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/register_farm.html
+++ b/register_farm.html
@@ -17,7 +17,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260427"></script>
+  <script src="./menu.js?v=20260428"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/repackaging_planner.html
+++ b/repackaging_planner.html
@@ -11,7 +11,7 @@
   <meta property="og:type" content="website">
   <link rel="icon" type="image/png" href="https://raw.githubusercontent.com/TrueSightDAO/.github/main/assets/20240612_truesight_dao_logo_square.png">
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260427"></script>
+  <script src="./menu.js?v=20260428"></script>
   <script src="./tdg_balance.js"></script>
   <title>Repackaging Planner - TrueSight DAO</title>
   <style>

--- a/report_capital_injection.html
+++ b/report_capital_injection.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260427"></script>
+    <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/report_contribution.html
+++ b/report_contribution.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260427"></script>
+    <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/report_dao_expenses.html
+++ b/report_dao_expenses.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260427"></script>
+    <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./expense-form-utils.js"></script>
     <script src="./js/treasury_cache.js"></script>

--- a/report_inventory_movement.html
+++ b/report_inventory_movement.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260427"></script>
+    <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     <script src="./scripts/permissions.js"></script>

--- a/report_sales.html
+++ b/report_sales.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260427"></script>
+    <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
     
     <style>

--- a/report_tree_planting.html
+++ b/report_tree_planting.html
@@ -17,7 +17,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260427"></script>
+  <script src="./menu.js?v=20260428"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/restock_recommender.html
+++ b/restock_recommender.html
@@ -24,7 +24,7 @@
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260427"></script>
+    <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         body {

--- a/review_proposal.html
+++ b/review_proposal.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260427"></script>
+    <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         * {

--- a/scanner.html
+++ b/scanner.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260427"></script>
+    <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
     
     <style>

--- a/service-worker.js
+++ b/service-worker.js
@@ -41,7 +41,7 @@ const URLS_TO_CACHE = [
   './withdraw_voting_rights.html',
   './governor_contributor_admin.html',
   // Scripts
-  './menu.js?v=20260427',
+  './menu.js?v=20260428',
   './routes.js',
   './service-worker.js',
   './js/treasury_cache.js',

--- a/shipping_planner.html
+++ b/shipping_planner.html
@@ -53,7 +53,7 @@
     </script>
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCS5tz9sp9mWG6d_glVO19UUk8ZyZ3LdbQ&callback=onGoogleMapsReady&v=weekly&loading=async&libraries=places"></script>
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260427"></script>
+    <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./js/treasury_cache.js"></script>
     

--- a/store_interaction_history.html
+++ b/store_interaction_history.html
@@ -20,7 +20,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260427"></script>
+    <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/stores_by_status.html
+++ b/stores_by_status.html
@@ -15,7 +15,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260427"></script>
+    <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/stores_nearby.html
+++ b/stores_nearby.html
@@ -45,7 +45,7 @@
     </script>
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBWmnvjWeYIEju0JLbfN-Z09k1HEsXzWe4&callback=onGoogleMapsReady&v=weekly&loading=async&libraries=places"></script>
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260427"></script>
+    <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
     
     <!-- Leaflet.js for maps (no API key required) -->

--- a/submit_feedback.html
+++ b/submit_feedback.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260427"></script>
+    <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/update_qr_code.html
+++ b/update_qr_code.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260427"></script>
+    <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/edgar_payload_helper.js"></script>
 

--- a/verify_request.html
+++ b/verify_request.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260427"></script>
+  <script src="./menu.js?v=20260428"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/view_inventory_holdings.html
+++ b/view_inventory_holdings.html
@@ -14,7 +14,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260427"></script>
+    <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./js/treasury_cache.js"></script>
 

--- a/view_open_proposals.html
+++ b/view_open_proposals.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260427"></script>
+    <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/withdraw_voting_rights.html
+++ b/withdraw_voting_rights.html
@@ -15,7 +15,7 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260427"></script>
+  <script src="./menu.js?v=20260428"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {


### PR DESCRIPTION
## Summary

Two operator-feedback follow-ups to [#184](https://github.com/TrueSightDAO/dapp/pull/184).

### 1. `governor_contributor_admin.html` matches the standard page layout

The page now mirrors `register_farm.html` / `notarize.html` etc.:

| Before | After |
|---|---|
| No logo, no footer | Standard 200px TrueSightDAO logo header + `dapp_footer_links.js` auto-inserts \"Reload Latest Version\" + \"View Source Code\" |
| No tdgBalanceBadge / translate widget | Standard top stripe with both |
| Jumped straight to "Loading…" then "Welcome, X. Permission verified." in one block | Standard rhythm: \"Verifying your digital signature…\" loading status → \"Welcome back, &lt;name&gt;!\" once identity is confirmed → form (or permission-denied UI) |

Identity check uses `DaoMembersCache.findByPublicKey()` (CDN-cached `dao_members.json`, ~50–150ms) instead of the `assetVerify` GAS round-trip the older pages use (1–3s). The permission gate runs after, reusing the same fetched snapshot — single network call total. This is also the answer to "why does signature verification take so long on the other pages": they call the GAS web app, which executes a full Apps Script (voting weight + holdings + asset values) per request. Migrating those pages to the cache pattern is a separate sweep.

### 2. New "Governor only" menu section

Governor-gated surfaces now live under a dedicated dropdown section instead of being scattered:

```
Home
└── Governor only
    ├── Governor Chat              (was top-level, section '')
    └── Add New Contributor        (was under "Identity & Governance")
└── Community Contributions
    └── …
└── Inventory & ledger
    └── …
└── …
```

Section order is "first occurrence wins", so "Governor only" surfaces right after Home, which feels right since it's the one role-restricted bucket.

### Cache-busting

Bumped `menu.js?v=20260428` across all 27 HTML pages + `service-worker.js` `URLS_TO_CACHE` per the convention in the menu.js header comment.

## Test plan

- [ ] Open `/governor_contributor_admin.html`. Logo at top, footer links at bottom, "Verifying your digital signature…" briefly visible, then "Welcome back, <name>!" appears.
- [ ] Open the nav dropdown on any page. \"Governor only\" group appears right after Home with both Governor Chat and Add New Contributor inside it.
- [ ] Hard-refresh confirms service worker re-caches with the new `?v=20260428`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)