### PR TITLE
perf(dapp): cache-first signature verify on the four reporter pages

### DIFF
--- a/report_contribution.html
+++ b/report_contribution.html
@@ -18,6 +18,7 @@
     <script src="./routes.js"></script>
     <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
+    <script src="./scripts/dao_members_cache.js"></script>
 
     <style>
         body {
@@ -431,8 +432,6 @@
             submitBtn.textContent = isPostSubmission ? 'Submit Another Contribution' : 'Submit Contribution Report';
         }        
 
-        const API_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
-            || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
         const DAO_FORMS_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.daoForms)
             || 'https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec';
         const EDGAR_PING = (window.Routes && window.Routes.edgar && window.Routes.edgar.ping)
@@ -1101,22 +1100,16 @@
 
             try {
                 const timestamp = new Date().toISOString();
-                const response = await fetch(`${API_ENDPOINT}?signature=${encodeURIComponent(publicKey)}`);
-                const data = await response.json();
-
-                if (data.error) {
-                    if (data.error.includes('No matching')) {
-                        statusElement.innerHTML = 'Your digital signature is not registered. <a href="./create_signature.html">Please register it first</a>.';
-                        statusElement.className = 'error fade-in';
-                        return;
-                    } else {
-                        statusElement.textContent = 'Error: ' + data.error;
-                        statusElement.className = 'error fade-in';
-                        return;
-                    }
+                // Cache-first identity lookup. dao_members.json on treasury-cache is
+                // CDN-served (~50–150ms) vs the assetVerify GAS round-trip (1–3s).
+                const lookup = await window.DaoMembersCache.findByPublicKey(publicKey);
+                if (!lookup.contributor) {
+                    statusElement.innerHTML = 'Your digital signature is not registered. <a href="./create_signature.html">Please register it first</a>.';
+                    statusElement.className = 'error fade-in';
+                    return;
                 }
 
-                contributorName = data.contributor_name;
+                contributorName = lookup.contributor.name;
                 document.getElementById('info').style.display = 'block';
                 document.getElementById('welcome').textContent = `Welcome back, ${contributorName}!`;
                 document.getElementById('welcome').style.display = 'block';

--- a/report_dao_expenses.html
+++ b/report_dao_expenses.html
@@ -18,6 +18,7 @@
     <script src="./routes.js"></script>
     <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
+    <script src="./scripts/dao_members_cache.js"></script>
     <script src="./expense-form-utils.js"></script>
     <script src="./js/treasury_cache.js"></script>
 
@@ -379,8 +380,6 @@
     </div>
 
     <script>
-        const API_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
-            || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
         const DAO_FORMS_BASE = (window.Routes && window.Routes.gas && window.Routes.gas.daoForms)
             || 'https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec';
         const EDGAR_PING = (window.Routes && window.Routes.edgar && window.Routes.edgar.ping)
@@ -1616,22 +1615,16 @@
             }
 
             try {
-                const response = await fetch(`${API_ENDPOINT}?signature=${encodeURIComponent(publicKey)}`);
-                const data = await response.json();
-
-                if (data.error) {
-                    if (data.error.includes('No matching')) {
-                        statusElement.innerHTML = 'Your digital signature is not registered. <a href="./create_signature.html">Please register it first</a>.';
-                        statusElement.className = 'error fade-in';
-                        return;
-                    } else {
-                        statusElement.textContent = 'Error: ' + data.error;
-                        statusElement.className = 'error fade-in';
-                        return;
-                    }
+                // Cache-first identity lookup. dao_members.json on treasury-cache is
+                // CDN-served (~50–150ms) vs the assetVerify GAS round-trip (1–3s).
+                const lookup = await window.DaoMembersCache.findByPublicKey(publicKey);
+                if (!lookup.contributor) {
+                    statusElement.innerHTML = 'Your digital signature is not registered. <a href="./create_signature.html">Please register it first</a>.';
+                    statusElement.className = 'error fade-in';
+                    return;
                 }
 
-                contributorName = data.contributor_name;
+                contributorName = lookup.contributor.name;
                 document.getElementById('info').style.display = 'block';
                 document.getElementById('welcome').textContent = `Welcome back, ${contributorName}!`;
                 document.getElementById('welcome').style.display = 'block';

--- a/report_inventory_movement.html
+++ b/report_inventory_movement.html
@@ -404,8 +404,6 @@
     <!-- Include jsQR library via CDN -->
     <script src="https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.min.js"></script>
     <script>
-        const API_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
-            || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
         const QR_CODE_BASE = (window.Routes && window.Routes.gas && window.Routes.gas.qrCodes)
             || 'https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec';
         const QR_CODE_ENDPOINT = `${QR_CODE_BASE}?list=true`;
@@ -2617,22 +2615,16 @@
             }
 
             try {
-                const response = await fetch(`${API_ENDPOINT}?signature=${encodeURIComponent(publicKey)}`);
-                const data = await response.json();
-
-                if (data.error) {
-                    if (data.error.includes('No matching')) {
-                        statusElement.innerHTML = 'Your digital signature is not registered. <a href="./create_signature.html">Please register it first</a>.';
-                        statusElement.className = 'error fade-in';
-                        return;
-                    } else {
-                        statusElement.textContent = 'Error: ' + data.error;
-                        statusElement.className = 'error fade-in';
-                        return;
-                    }
+                // Cache-first identity lookup. dao_members.json on treasury-cache is
+                // CDN-served (~50–150ms) vs the assetVerify GAS round-trip (1–3s).
+                const lookup = await window.DaoMembersCache.findByPublicKey(publicKey);
+                if (!lookup.contributor) {
+                    statusElement.innerHTML = 'Your digital signature is not registered. <a href="./create_signature.html">Please register it first</a>.';
+                    statusElement.className = 'error fade-in';
+                    return;
                 }
 
-                contributorName = data.contributor_name;
+                contributorName = lookup.contributor.name;
                 document.getElementById('info').style.display = 'block';
                 document.getElementById('welcome').textContent = `Welcome back, ${contributorName}!`;
                 document.getElementById('welcome').style.display = 'block';

--- a/report_sales.html
+++ b/report_sales.html
@@ -17,6 +17,7 @@
     <script src="./routes.js"></script>
     <script src="./menu.js?v=20260428"></script>
     <script src="./tdg_balance.js"></script>
+    <script src="./scripts/dao_members_cache.js"></script>
     
     <style>
         body {
@@ -396,8 +397,6 @@
                 .catch(err => console.warn('Service Worker registration failed:', err));
         }
 
-        const API_ENDPOINT = (window.Routes && window.Routes.gas && window.Routes.gas.assetVerify)
-            || 'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec';
         const QR_CODE_BASE = (window.Routes && window.Routes.gas && window.Routes.gas.qrCodes)
             || 'https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec';
         const QR_CODE_ENDPOINT = `${QR_CODE_BASE}?list=true`;
@@ -1374,22 +1373,16 @@
             }
 
             try {
-                const response = await fetch(`${API_ENDPOINT}?signature=${encodeURIComponent(publicKey)}`);
-                const data = await response.json();
-
-                if (data.error) {
-                    if (data.error.includes('No matching')) {
-                        statusElement.innerHTML = 'Your digital signature is not registered. <a href="./create_signature.html">Please register it first</a>.';
-                        statusElement.className = 'error fade-in';
-                        return;
-                    } else {
-                        statusElement.textContent = 'Error: ' + data.error;
-                        statusElement.className = 'error fade-in';
-                        return;
-                    }
+                // Cache-first identity lookup. dao_members.json on treasury-cache is
+                // CDN-served (~50–150ms) vs the assetVerify GAS round-trip (1–3s).
+                const lookup = await window.DaoMembersCache.findByPublicKey(publicKey);
+                if (!lookup.contributor) {
+                    statusElement.innerHTML = 'Your digital signature is not registered. <a href="./create_signature.html">Please register it first</a>.';
+                    statusElement.className = 'error fade-in';
+                    return;
                 }
 
-                contributorName = data.contributor_name;
+                contributorName = lookup.contributor.name;
                 document.getElementById('info').style.display = 'block';
                 document.getElementById('welcome').textContent = `Welcome back, ${contributorName}!`;
                 document.getElementById('welcome').style.display = 'block';


### PR DESCRIPTION
## Summary

The \"Verifying your digital signature…\" splash on the four highest-traffic reporter pages was calling the `assetVerify` Apps Script web app per page load, which executes a full GAS run (voting weight + holdings + asset values per request). Typical round-trip 1–3s — visibly slow on mobile.

Switches all four to `DaoMembersCache.findByPublicKey()` (CDN-served `dao_members.json`, ~50–150ms).

| Page | Before | After |
|---|---|---|
| `report_contribution.html` | `fetch(assetVerify?signature=…)` (GAS) | `DaoMembersCache.findByPublicKey()` (CDN) |
| `report_sales.html` | same | same |
| `report_dao_expenses.html` | same | same |
| `report_inventory_movement.html` | same | same |

## Per-page changes

- Add `<script src=\"./scripts/dao_members_cache.js\"></script>` (already loaded on `report_inventory_movement.html` from #184; new on the other three).
- Replace the `fetch(API_ENDPOINT?signature=…)` + `data.error` + `data.contributor_name` block with the cache call. Same \"no matching signature → redirect to create_signature.html\" branch via `lookup.contributor === null`.
- Drop the now-unused `const API_ENDPOINT` declaration on each page (-2 lines × 4 pages).

Net: +35 / -64 lines. No menu / cache-version bump needed — internal to each page's script tag.

## What's NOT changed

The slow GAS path stays available via `window.Routes.gas.assetVerify` for any caller that genuinely needs DAO-wide aggregates (voting rights circulated, total assets, asset-per-circulated-voting-right, etc.). Only the per-page **identity** check is migrated here. Pages like `withdraw_voting_rights.html` that need real-time financial data continue to hit GAS directly.

## Test plan

- [ ] Open each of the four pages signed in. Confirm \"Verifying your digital signature…\" splash is now sub-second.
- [ ] Open one of the pages signed-out (clear `localStorage.publicKey`). Confirm the redirect to `create_signature.html` still works.
- [ ] Open one of the pages with a public key that doesn't match any contributor (e.g. a freshly-generated one). Confirm \"Your digital signature is not registered. Please register it first\" link still appears.
- [ ] Submit a contribution / sale / expense / inventory movement on each page end-to-end. Confirm the existing submit flow is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)