### PR TITLE
fix(store-history): align Status dropdown with the canonical States tab

### DIFF
--- a/store_interaction_history.html
+++ b/store_interaction_history.html
@@ -512,20 +512,31 @@
             <p class="help-text">Submits a signed <code>[RETAIL FIELD REPORT EVENT]</code> (with optional attachments) to <strong>Edgar</strong> at <code>/dao/submit_contribution</code>. Edgar logs the row to Telegram Chat Logs, uploads any attachment to <code>TrueSightDAO/store_interaction_attachments</code>, and fires an async GAS scanner that updates the Hit List Status, <strong>DApp Remarks</strong>, and <strong>Stores Visits Field Reports</strong> (one row per submission, dedup keyed on Update ID).</p>
 
             <label for="editStatus">Status</label>
+            <!-- Source of truth: Hit List "States" tab column B (exact_value).
+                 Order mirrors that tab — AI:* values cluster together so an
+                 operator scanning for "AI: Enrich with contact" finds it next
+                 to the other AI-driven statuses. Keep in sync; if a new
+                 status lands on the States tab, add it here verbatim. -->
             <select id="editStatus" data-requires-signature="true">
                 <option value="Research">Research</option>
+                <option value="AI: Shortlisted">AI: Shortlisted</option>
+                <option value="AI: Photo rejected">AI: Photo rejected</option>
+                <option value="AI: Photo needs review">AI: Photo needs review</option>
+                <option value="AI: Enrich with contact">AI: Enrich with contact</option>
+                <option value="AI: Email found">AI: Email found</option>
+                <option value="AI: Contact Form found">AI: Contact Form found</option>
+                <option value="AI: Enrich — manual">AI: Enrich — manual</option>
+                <option value="AI: Warm up prospect">AI: Warm up prospect</option>
+                <option value="AI: Prospect replied">AI: Prospect replied</option>
                 <option value="Shortlisted">Shortlisted</option>
                 <option value="Instagram Followed">Instagram Followed</option>
                 <option value="Contacted">Contacted</option>
-                <option value="AI: Warm up prospect">AI: Warm up prospect</option>
-                <option value="AI: Prospect replied">AI: Prospect replied</option>
                 <option value="Manager Follow-up">Manager Follow-up</option>
                 <option value="Bulk Info Requested">Bulk Info Requested</option>
                 <option value="Meeting Scheduled">Meeting Scheduled</option>
                 <option value="Followed Up">Followed Up</option>
                 <option value="Partnered">Partnered</option>
                 <option value="On Hold">On Hold</option>
-                <option value="Deferred / Revisit later">Deferred / Revisit later</option>
                 <option value="Rejected">Rejected</option>
                 <option value="Not Appropriate">Not Appropriate</option>
             </select>


### PR DESCRIPTION
## Summary

Operator hit a missing `AI: Enrich with contact` option on `store_interaction_history.html` for store `sunmoon__83-south-stewart-street__sonora__ca` — wanted to flip the row into the enrichment queue but the option wasn't there. Root cause: the dropdown shipped with a hand-curated list that drifted from the canonical Hit-List `States` tab (column B `exact_value` is source of truth per the tab's own header).

Aligned the full dropdown to match the States tab verbatim. Seven AI:* statuses were missing.

## Changes

### Added (in canonical order, AI:* clustered together)

- `AI: Shortlisted`
- `AI: Photo rejected`
- `AI: Photo needs review`
- **`AI: Enrich with contact`** — the one the operator needed
- `AI: Email found`
- `AI: Contact Form found`
- `AI: Enrich — manual`

### Removed

- `Deferred / Revisit later` — not on the canonical States tab. Existing Hit-List rows that still carry that value continue to display fine; this change only restricts what's selectable going forward.

### Code-comment guard

Added a comment at the top of the `<select>` noting the source-of-truth contract: any new Status added to the States tab should be added here verbatim. Catches drift at edit time.

## Test plan

- [ ] Open `https://dapp.truesight.me/store_interaction_history.html?store=sunmoon__83-south-stewart-street__sonora__ca&shop=Sun%26Moon` after merge → dropdown contains "AI: Enrich with contact".
- [ ] Sign in with a verified digital signature → "Update Status & Shop Type" lets you submit the new status. Confirm the submission lands on Telegram Chat Logs as a `[RETAIL FIELD REPORT EVENT]` and the GAS scanner promotes the Hit List row to `AI: Enrich with contact`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)