### PR TITLE
fix(ui): clarify Contribution vs Capital Injection, reorganize index

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,7 @@
 
       <div class="module-card">
         <h3><a href="./report_contribution.html">DAO Contribution Reporter</a></h3>
-        <p>Report contributions to the DAO for $TDG awards.</p>
+        <p>Report volunteer time or out-of-pocket expenses for DAO operations.</p>
         <p><strong>Features</strong>:</p>
         <ul>
           <li>Select contributors and contribution type</li>
@@ -353,23 +353,6 @@
       <h2>Inventory & ledger</h2>
       <p style="color:#555;font-size:0.95rem;">Ledger operations, QR batching, shipping, and repackaging — tools tied to inventory on the Main Ledger and managed AGL sheets.</p>
       <div class="module-card">
-        <h3><a href="./report_capital_injection.html">Capital Injection Reporter</a></h3>
-        <p>Report capital injections to managed AGL ledgers.</p>
-        <p><strong>Features</strong>:</p>
-        <ul>
-          <li>Select target managed ledger</li>
-          <li>Specify amount (USD) and description</li>
-          <li>Attach supporting documentation</li>
-          <li>Creates double-entry transactions (Assets + Equity)</li>
-        </ul>
-        <p><strong>Usage</strong>:</p>
-        <ol>
-          <li>Open <a href="./report_capital_injection.html">Capital Injection Reporter</a>.</li>
-          <li>Select ledger and enter amount.</li>
-          <li>Submit report with proof to our <a href="https://t.me/TrueSightDAO">Telegram channel</a>.</li>
-        </ol>
-      </div>
-      <div class="module-card">
         <h3><a href="./report_dao_expenses.html">Inventory Expense Reporter</a></h3>
         <p>Report DAO inventory expenses.</p>
         <p><strong>Features</strong>:</p>
@@ -496,6 +479,28 @@
     </div>
 
     <div class="section">
+      <h2>Investment & Financing</h2>
+      <p style="color:#555;font-size:0.95rem;">For external investors wiring funds into AGL-managed contracts. Not for operational expenses — use the DAO Contribution Reporter for out-of-pocket costs.</p>
+      <div class="module-card">
+        <h3><a href="./report_capital_injection.html">Capital Injection Reporter</a></h3>
+        <p>Report funds wired into an AGL-managed ledger or contract.</p>
+        <p><strong>Features</strong>:</p>
+        <ul>
+          <li>Select target managed ledger</li>
+          <li>Specify amount (USD) and description</li>
+          <li>Attach supporting documentation</li>
+          <li>Creates double-entry transactions (Assets + Equity)</li>
+        </ul>
+        <p><strong>Usage</strong>:</p>
+        <ol>
+          <li>Open <a href="./report_capital_injection.html">Capital Injection Reporter</a>.</li>
+          <li>Select ledger and enter amount.</li>
+          <li>Submit report with proof to our <a href="https://t.me/TrueSightDAO">Telegram channel</a>.</li>
+        </ol>
+      </div>
+    </div>
+
+    <div class="section">
       <h2>Sunmint Tree Planting Program</h2>
       <div class="module-card">
         <h3><a href="./register_farm.html">Register Your Farm</a></h3>
@@ -532,23 +537,7 @@
     </div>
 
     <div class="section">
-      <h2>Community Contributions</h2>
-      <div class="module-card">
-        <h3><a href="./report_contribution.html">DAO Contribution Reporter</a></h3>
-        <p>Report contributions to the DAO for $TDG awards.</p>
-        <p><strong>Features</strong>:</p>
-        <ul>
-          <li>Select contributors and contribution type</li>
-          <li>Specify amount and description</li>
-          <li>Attach proof (image/PDF) and share signed report</li>
-        </ul>
-        <p><strong>Usage</strong>:</p>
-        <ol>
-          <li>Open <a href="./report_contribution.html">DAO Contribution Reporter</a>.</li>
-          <li>Select contributors, type, and amount.</li>
-          <li>Submit report with proof to our <a href="https://t.me/TrueSightDAO">Telegram channel</a>.</li>
-        </ol>
-      </div>
+      <h2>Community & Feedback</h2>
       <div class="module-card">
         <h3><a href="./submit_feedback.html">Content Feedback Submission</a></h3>
         <p>Submit content ideas and feedback for Agroverse's social media and blog strategy.</p>

--- a/report_capital_injection.html
+++ b/report_capital_injection.html
@@ -259,7 +259,7 @@
         </div>        
         <h1>Capital Injection Report</h1>
         <p id="description">
-            Report capital injection to TrueSight DAO. Upload supporting documentation and specify the ledger and amount.
+            <strong>For external investors only.</strong> Use this to report funds wired directly into an AGL-managed contract or ledger. If you paid for DAO operations out-of-pocket (software, travel, supplies), use the <a href="./report_contribution.html">DAO Contribution Report</a> instead.
         </p>
         
         <div id="welcome" style="display: none;"></div>

--- a/report_contribution.html
+++ b/report_contribution.html
@@ -345,7 +345,7 @@
         </div>        
         <h1>DAO Contribution Report</h1>
         <p id="description">
-            Submit a contribution report for DAO members.
+            Report time spent or out-of-pocket expenses (e.g. software, tools, travel) for DAO operations. Choose <strong>Time</strong> for volunteer hours, or <strong>USD</strong> for reimbursable expenses you personally paid.
         </p>
         <div id="welcome" style="display: none;"></div>
         <p id="status" class="fade-in">Verifying your digital signature...</p>


### PR DESCRIPTION
## What
Resolves the confusion between DAO Contribution and Capital Injection by updating copy and reorganizing the index page.

## Changes
- **report_contribution.html** — description now clarifies it covers both volunteer time AND out-of-pocket expenses (software, tools, travel, etc.)
- **report_capital_injection.html** — description now states "For external investors only" with a cross-link to the Contribution Reporter
- **index.html** — reorganized:
  - New "Investment & Financing" section (Capital Injection only)
  - "Community Contributions" renamed to "Community & Feedback" (Feedback only; removed duplicate Contribution card)
  - Updated Quick Access Contribution card copy

## Why
Both humans and AI agents were confusing the two events. Contribution sounded like volunteer-only; Capital Injection sounded like it covered any money spent. This makes the distinction explicit on the surface.