### PR TITLE
fix(routes): point qrCodes at admin@truesight.me deployment (post-migration)

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -25,7 +25,7 @@
 
   var directGas = {
     assetVerify:      'https://script.google.com/macros/s/AKfycbygmwRbyqse-dpCYMco0rb93NSgg-Jc1QIw7kUiBM7CZK6jnWnMB5DEjdoX_eCsvVs7/exec',
-    qrCodes:          'https://script.google.com/macros/s/AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL/exec',
+    qrCodes:          'https://script.google.com/macros/s/AKfycbyGD0CDkvjo7K9O1gPnnqmdXvaJt9FM2v39HHqiDud5wwU6Mf41wwIOFS-NDD93xqoL/exec',
     qrCodeGenerator:  'https://script.google.com/macros/s/AKfycbyGD0CDkvjo7K9O1gPnnqmdXvaJt9FM2v39HHqiDud5wwU6Mf41wwIOFS-NDD93xqoL/exec',
     daoForms:         'https://script.google.com/macros/s/AKfycbztpV3TUIRn3ftNW1aGHAKw32OBJrp_p1Pr9mMAttoyWFZyQgBRPU2T6eGhkmJtz7xV/exec',
     proposals:        'https://script.google.com/a/macros/agroverse.shop/s/AKfycbzgNstwRX1dWo17Dxny0t1ipJ6yLX02bTD_cKRuHr5RPJPemNVTj25mFhKo4UmR5Z7BIg/exec',


### PR DESCRIPTION
## Why this exists

PR TrueSightDAO/tokenomics#225 (2026-04-17) migrated the qr_code_web_service GAS project from the legacy *Api.TrueSight.me - QR code reader web service* project (scriptId \`1y6JVYwq…\`, owned by the original Google account) to a new admin@truesight.me project (scriptId \`1MnAsIQA…\`). Future GAS pushes go to the new project, but \`routes.js > directGas.qrCodes\` was never updated — the DApp kept calling the legacy deployment URL.

Symptom that surfaced today: PRs #257 (processBatch error visibility) and #259 (shipping_provider + tracking_number on list_unassigned_stripe_sessions) were both pushed to admin@truesight.me and verified live there, but \`update_qr_code.html\` still saw only the \`stripe_session_id\` field — because the page was still hitting the legacy deployment, which still runs the older code.

## Fix

Repoint \`qrCodes\` from:

\`\`\`
AKfycbxigq4-J0izShubqIC5k6Z7fgNRyVJLakfQ34HPuENiSpxuCG-wSq0g-wOAedZzzgaL  (legacy, scriptId 1y6JVYwq…)
\`\`\`

to:

\`\`\`
AKfycbyGD0CDkvjo7K9O1gPnnqmdXvaJt9FM2v39HHqiDud5wwU6Mf41wwIOFS-NDD93xqoL  (admin@truesight.me v2, scriptId 1MnAsIQA…)
\`\`\`

Verified live (after redeploying v2 against canonical HEAD via \`clasp redeploy\`):

| endpoint | result |
|---|---|
| \`?lookup=true&qr_code=…\` | success + 8 keys |
| \`?list_all=true\` | success + qr_codes array |
| \`?list_with_members=true\` | success + items array |
| \`?list_unassigned_stripe_sessions=true&for_qr_code=…\` | items now include \`{stripe_session_id, shipping_provider, tracking_number}\` |

\`qrCodeGenerator\` was already pointing at this same URL, so this just consolidates onto the new project the migration intended.

## Test plan

- [ ] Open \`update_qr_code.html\`, pick a QR with a Stripe session that has tracking populated → tracking number + shipping provider populate from that session's row.
- [ ] Open \`view_inventory_holdings.html\`, \`report_inventory_movement.html\`, \`report_sales.html\` (other consumers of \`gas.qrCodes\`) → still load QR list and member dropdowns correctly.
- [ ] Spot-check existing flows that submit QR updates to Edgar → still work (writes go through Edgar, not GAS, so unaffected).

## Follow-up

The legacy deployment under \`1y6JVYwq…\` is left running. A subsequent PR can retire it once we confirm no other caller (Wix, internal scripts, etc.) depends on the old URL.