### PR TITLE
Stores pages: pad statuses + Deferred option + clickable filename_original

### DIFF
--- a/store_interaction_history.html
+++ b/store_interaction_history.html
@@ -537,6 +537,7 @@
                 <option value="Followed Up">Followed Up</option>
                 <option value="Partnered">Partnered</option>
                 <option value="On Hold">On Hold</option>
+                <option value="Deferred / Revisit later">Deferred / Revisit later</option>
                 <option value="Rejected">Rejected</option>
                 <option value="Not Appropriate">Not Appropriate</option>
             </select>
@@ -1242,6 +1243,19 @@
         var keys = Object.keys(obj).filter(function (k) { return obj[k] !== '' && obj[k] !== undefined && obj[k] !== null; });
         keys.sort(function (a, b) { return a.localeCompare(b); });
         if (!keys.length) return '<p class="help-text">(empty)</p>';
+        // Resolve the GitHub blob URL (preferred for PDFs/HTML — opens directly
+        // in a browser tab) once, so the filename_original cell can render as a
+        // clickable link without a per-key network call.
+        var attachmentBlobUrl = '';
+        for (var ki = 0; ki < keys.length; ki++) {
+            var kk = keys[ki].toLowerCase().replace(/\s+/g, ' ');
+            if (kk === 'github_blob_url' || kk === 'github blob url' || kk === 'attachment github url') {
+                if (/^https?:\/\//i.test(String(obj[keys[ki]]))) {
+                    attachmentBlobUrl = String(obj[keys[ki]]);
+                    break;
+                }
+            }
+        }
         var html = '<dl class="kv-list">';
         keys.forEach(function (k) {
             var val = String(obj[k]);
@@ -1259,6 +1273,17 @@
                 inner = '<a href="' + escapeHtml(wu) + '" target="_blank" rel="noopener noreferrer" class="store-details-link">' + displayVal + '</a>';
             } else if (lk.indexOf('github') !== -1 && /^https?:\/\//i.test(val)) {
                 inner = '<a href="' + escapeHtml(val) + '" target="_blank" rel="noopener noreferrer" class="store-details-link">' + displayVal + '</a>';
+            } else if (lk === 'filename_original' || lk === 'original filename' || lk === 'attachment filename') {
+                // PDFs (and any other attachment whose preview iframe doesn't
+                // render inline on every browser) need the filename itself to
+                // link to the GitHub blob URL, which renders in a normal
+                // browser tab. We use the blob URL (not raw) because GitHub's
+                // raw host returns application/pdf without a Content-Disposition,
+                // which Chrome treats as a download — the blob URL gives an
+                // in-tab viewer.
+                if (attachmentBlobUrl) {
+                    inner = '<a href="' + escapeHtml(attachmentBlobUrl) + '" target="_blank" rel="noopener noreferrer" class="store-details-link">' + displayVal + '</a>';
+                }
             } else if (lk === 'email') {
                 inner = '<a href="mailto:' + escapeHtml(val) + '" class="store-details-link">' + displayVal + '</a>';
             } else if (lk === 'phone' || lk === 'cell phone') {

--- a/stores_by_status.html
+++ b/stores_by_status.html
@@ -734,10 +734,42 @@
         };
     }
 
+    /**
+     * Pad ``byKind`` so every option in ``allOptions`` has a row in the
+     * pipeline overview, even if the live data has 0 rows for that key.
+     * Without this, a status like "AI: Prospect replied" disappears from the
+     * overview the moment the field-team triages all replies (count drops to 0),
+     * and an operator scanning the pipeline can't tell whether the status
+     * exists at all. Zero-count rows render with a 0 count and no touch bars.
+     */
+    function padPipelineWithKnownOptions(byKind, allOptions, keyName) {
+        var present = {};
+        var i;
+        for (i = 0; i < byKind.length; i++) {
+            var v = byKind[i] && byKind[i][keyName];
+            if (v) present[v] = true;
+        }
+        var padded = byKind.slice();
+        for (i = 0; i < allOptions.length; i++) {
+            if (!present[allOptions[i]]) {
+                var stub = { count: 0 };
+                stub[keyName] = allOptions[i];
+                padded.push(stub);
+            }
+        }
+        // Sort: nonzero first (by count desc), then zero rows alphabetically so the
+        // pipeline-shape stays readable.
+        padded.sort(function (a, b) {
+            if ((a.count || 0) !== (b.count || 0)) return (b.count || 0) - (a.count || 0);
+            return String(a[keyName] || '').localeCompare(String(b[keyName] || ''));
+        });
+        return padded;
+    }
+
     function renderPipeline(data) {
         if (!pipelineBody) return;
-        var byStatus = data.by_status || [];
-        var byShop = data.by_shop_type || [];
+        var byStatus = padPipelineWithKnownOptions(data.by_status || [], STATUS_OPTIONS, 'status');
+        var byShop = padPipelineWithKnownOptions(data.by_shop_type || [], SHOP_TYPE_OPTIONS, 'shop_type');
         pipelineBody.innerHTML =
             '<div class="pipeline-block"><h3>Stores by status</h3><div class="pipeline-rows">' +
             renderPipelineRows(byStatus, 'status') +


### PR DESCRIPTION
Three fixes triggered by Gary 2026-04-30:

1. **stores_by_status.html** — pipeline overview now lists every status in `STATUS_OPTIONS` (and every shop type in `SHOP_TYPE_OPTIONS`), even when count is 0. Previously a status would disappear from the overview if no rows currently matched, making it hard to confirm whether 'AI: Prospect replied' / 'Deferred / Revisit later' / 'Bulk Info Requested' / etc. exist as recognized states. Sort order: nonzero rows by count desc, then zero rows alphabetically.
2. **store_interaction_history.html** — added `Deferred / Revisit later` to the status dropdown (was already in stores_by_status STATUS_OPTIONS but never propagated to the per-store editor).
3. **store_interaction_history.html** — `filename_original` (with aliases) now renders as a clickable link to the github_blob_url for the attachment. Critical for PDFs, which the existing iframe preview sometimes can't inline (Chrome force-downloads when GitHub raw returns `application/pdf` without `Content-Disposition: inline`). The blob URL gives an in-tab GitHub viewer.