### PR TITLE
feat(warmup-review): mobile triage page + signed Send button

### DIFF
--- a/index.html
+++ b/index.html
@@ -347,6 +347,22 @@
           <li>Search and expand rows as needed.</li>
         </ol>
       </div>
+      <div class="module-card">
+        <h3><a href="./warmup_review.html">Warm-up Review</a></h3>
+        <p>Triage pending warm-up Gmail drafts: lint flags risky ones (generic <code>info@</code>, fallback shop name, foreign-script venue, etc.), Hosts Circles=Yes prospects get a blue badge, clean cohort goes to the bottom for batch send.</p>
+        <p><strong>Features</strong>:</p>
+        <ul>
+          <li>Mobile-first scan view sorted red-first</li>
+          <li>Tap <strong>Send</strong> to ship the draft from your Gmail (signed via <code>[WARMUP SEND EVENT]</code>)</li>
+          <li>Tap <strong>Edit in Gmail</strong> to deep-link into the draft for hand-editing first</li>
+        </ul>
+        <p><strong>Usage</strong>:</p>
+        <ol>
+          <li>Open <a href="./warmup_review.html">Warm-up Review</a>.</li>
+          <li>Scan top-to-bottom; reds + Hosts Circles float up.</li>
+          <li>Tap Send for trusted drafts; tap Edit in Gmail for ones you want to tweak.</li>
+        </ol>
+      </div>
     </div>
 
     <div class="section">

--- a/menu.js
+++ b/menu.js
@@ -24,6 +24,7 @@
     { title: 'Stores Nearby', url: './stores_nearby.html', section: 'Retail & field activity' },
     { title: 'Stores by Status', url: './stores_by_status.html', section: 'Retail & field activity' },
     { title: 'Store Interaction History', url: './store_interaction_history.html', section: 'Retail & field activity' },
+    { title: 'Warm-up Review', url: './warmup_review.html', section: 'Retail & field activity' },
     { title: 'Register Your Farm', url: './register_farm.html', section: 'Sunmint Tree Planting Program' },
     { title: 'Report Tree Planting', url: './report_tree_planting.html', section: 'Sunmint Tree Planting Program' },
     { title: 'Digital Signature Creator', url: './create_signature.html', section: 'Identity & Governance' },

--- a/warmup_review.html
+++ b/warmup_review.html
@@ -1,0 +1,417 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="description" content="Review and send warm-up email drafts staged in Gmail.">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Warm-up Review · TrueSight DAO</title>
+  <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
+
+  <script src="./routes.js"></script>
+  <script src="./menu.js?v=20260430"></script>
+  <script src="./tdg_balance.js"></script>
+  <script src="./scripts/dao_members_cache.js"></script>
+  <script src="./scripts/permissions.js"></script>
+
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+      margin: 1rem;
+      padding: 0;
+      background: #f5f5f5;
+      color: #222;
+      box-sizing: border-box;
+    }
+    .container {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 1rem;
+      background: white;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.08);
+    }
+    h1 { font-size: 1.5rem; margin: 0 0 0.5rem; text-align: center; }
+    .meta { color: #666; font-size: 0.85rem; text-align: center; margin-bottom: 1rem; }
+    #status { text-align: center; padding: 0.5rem; min-height: 1.2rem; }
+    .toolbar {
+      display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center;
+      padding: 0.5rem 0; margin-bottom: 0.75rem;
+    }
+    .toolbar .btn-refresh {
+      background: #007bff; color: #fff; border: none; border-radius: 4px;
+      padding: 0.5rem 0.9rem; font-size: 0.95rem; cursor: pointer; min-height: 40px;
+    }
+    .toolbar .btn-refresh:disabled { background: #6c757d; cursor: not-allowed; }
+    .summary {
+      display: flex; gap: 0.75rem; flex-wrap: wrap;
+      background: #f7f7f7; padding: 0.75rem; border-radius: 6px;
+      font-size: 0.85rem;
+    }
+    .summary div b { display: block; font-size: 1.1rem; }
+    .draft {
+      border: 1px solid #ddd; border-left: 4px solid #ddd;
+      border-radius: 6px; padding: 0.85rem; margin-bottom: 0.75rem;
+      background: white;
+    }
+    .draft.red    { border-left-color: #d33; }
+    .draft.yel    { border-left-color: #e90; }
+    .draft.blu    { border-left-color: #28a; }
+    .draft.clean  { border-left-color: #2a2; }
+    .draft.sending { opacity: 0.55; }
+    .draft.sent { display: none; }
+    .row1 { display: flex; align-items: baseline; gap: 0.5rem; flex-wrap: wrap; }
+    .recipient { font-weight: 600; word-break: break-all; }
+    .shop { color: #555; }
+    .city { color: #888; font-size: 0.8rem; }
+    .aw { background: #28a; color: white; padding: 2px 6px; border-radius: 3px; font-size: 0.7rem; font-weight: 600; }
+    .subject { font-weight: 600; margin: 0.4rem 0; font-size: 1rem; line-height: 1.3; }
+    .flags { margin: 0.3rem 0; display: flex; gap: 0.3rem; flex-wrap: wrap; }
+    .flag { padding: 2px 7px; border-radius: 3px; font-size: 0.7rem; font-weight: 600; }
+    .f-red { background: #fde; color: #a00; }
+    .f-yel { background: #ffe9b3; color: #850; }
+    .f-blu { background: #def; color: #036; }
+    .actions { margin-top: 0.6rem; display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+    .btn-send {
+      background: #2a8c3d; color: white; border: none; border-radius: 4px;
+      padding: 0.55rem 1rem; font-size: 0.95rem; font-weight: 600; cursor: pointer;
+      min-width: 88px; min-height: 40px;
+    }
+    .btn-send:disabled { background: #6c757d; cursor: not-allowed; }
+    .btn-send:active { transform: scale(0.97); }
+    .open-gmail { color: #06c; text-decoration: none; font-size: 0.9rem; padding: 0.5rem 0; }
+    .open-gmail:hover { text-decoration: underline; }
+    .row-status { font-size: 0.8rem; color: #555; margin-left: auto; }
+    .row-status.error { color: #c00; }
+    details > summary { cursor: pointer; font-size: 0.85rem; color: #555; margin-top: 0.5rem; user-select: none; }
+    pre.body {
+      white-space: pre-wrap; word-wrap: break-word; background: #fafafa;
+      padding: 0.75rem; border-radius: 4px; margin-top: 0.5rem;
+      font: 0.85rem ui-monospace, SFMono-Regular, Menlo, monospace;
+      max-height: 360px; overflow-y: auto;
+    }
+    .empty { text-align: center; padding: 2rem 0; color: #888; }
+    .toast {
+      position: fixed; bottom: 1rem; left: 50%; transform: translateX(-50%);
+      background: #222; color: white; padding: 0.7rem 1.1rem; border-radius: 6px;
+      font-size: 0.9rem; opacity: 0; transition: opacity 0.2s;
+      pointer-events: none; z-index: 1000;
+      max-width: 90vw; text-align: center;
+    }
+    .toast.show { opacity: 1; }
+    .toast.error { background: #b00020; }
+
+    @media (max-width: 720px) {
+      body { margin: 0.5rem; }
+      .container { padding: 0.75rem; }
+      h1 { font-size: 1.3rem; }
+      .summary div b { font-size: 1rem; }
+      .draft { padding: 0.7rem; }
+    }
+  </style>
+</head>
+<body>
+  <div id="navDropdown" style="margin: 1rem 0; text-align: center;"></div>
+  <div id="tdgBalanceBadge"></div>
+  <div class="container">
+    <h1>Warm-up Review</h1>
+    <div class="meta">Linted Gmail drafts pending review · sorted red-first</div>
+    <p id="status" aria-live="polite">Verifying access…</p>
+    <div id="gateContainer"></div>
+    <div id="content" style="display: none;">
+      <div class="toolbar">
+        <button id="btnRefresh" class="btn-refresh" type="button">Refresh</button>
+        <span id="lastFetchedAt" style="color:#888; font-size:0.8rem;"></span>
+      </div>
+      <div id="summary" class="summary"></div>
+      <div id="draftList" style="margin-top: 1rem;"></div>
+    </div>
+  </div>
+  <div id="toast" class="toast" role="status" aria-live="polite"></div>
+
+  <script>
+    const ACTION_ROLE = 'warmup.send';
+    const EVENT_TAG = '[WARMUP SEND EVENT]';
+
+    const GAS_URL = (window.Routes && window.Routes.gas && window.Routes.gas.storesHitList)
+        || 'https://script.google.com/macros/s/AKfycbwoBqZnDS4JRRdFkxSXdlGt-qIn-RauMcORuDHeWs29oQ2CpJ3L4A10uM8se9anL108/exec';
+    const EDGAR_SUBMIT = (window.Routes && window.Routes.edgar && window.Routes.edgar.submit)
+        || 'https://edgar.truesight.me/dao/submit_contribution';
+
+    const publicKey = (function () {
+      try { return localStorage.getItem('publicKey') || ''; } catch (_) { return ''; }
+    })();
+    const privateKey = (function () {
+      try { return localStorage.getItem('privateKey') || ''; } catch (_) { return ''; }
+    })();
+    let contributorName = '';
+
+    const statusEl  = document.getElementById('status');
+    const contentEl = document.getElementById('content');
+    const summaryEl = document.getElementById('summary');
+    const listEl    = document.getElementById('draftList');
+    const refreshBtn = document.getElementById('btnRefresh');
+    const lastFetchedEl = document.getElementById('lastFetchedAt');
+    const toastEl   = document.getElementById('toast');
+
+    function setStatus(msg, kind) {
+      statusEl.textContent = msg || '';
+      statusEl.className = kind || '';
+    }
+
+    function escapeHtml(s) {
+      return String(s == null ? '' : s)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+
+    function showToast(msg, isError) {
+      toastEl.textContent = msg;
+      toastEl.className = 'toast show' + (isError ? ' error' : '');
+      setTimeout(function () { toastEl.className = 'toast'; }, 3500);
+    }
+
+    function base64ToArrayBuffer(b64) {
+      const bin = atob(b64);
+      const out = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+      return out.buffer;
+    }
+    function arrayBufferToBase64(buf) {
+      return btoa(String.fromCharCode.apply(null, new Uint8Array(buf)));
+    }
+
+    // Lint rules — mirrors market_research/scripts/preview_warmup_drafts.py
+    // Keep this in sync; rules fire on the 500-char body_preview from sheet.
+    const GENERIC_INBOX_RE = /^(info|sales|hello|contact|admin|support|orders|hi|team|enquiry|enquiries|inquiry|inquiries)@/i;
+    const GENERIC_SALUTATION_RE = /^\s*(hi|hello|hey|dear)\s+(there|team|folks|friends)\b/i;
+    const PLACEHOLDER_RE = /\{\{[^}]+\}\}|\[[A-Z_]{3,}\]/;
+    const NON_LATIN_RE = /[Ѐ-ӿ一-鿿぀-ヿ؀-ۿ]/;
+
+    function lintDraft(d) {
+      const flags = [];
+      const subj = d.subject || '';
+      const body = d.body_preview || '';
+      const em = d.to_email || '';
+      if (!subj.trim()) flags.push(['red', 'subject empty']);
+      if (!body.trim()) flags.push(['red', 'body empty']);
+      else if (body.length < 200) flags.push(['red', 'body too short (' + body.length + ')']);
+      if (body.toLowerCase().indexOf('your shop') !== -1) flags.push(['red', 'fallback shop name']);
+      if (em && GENERIC_INBOX_RE.test(em)) flags.push(['red', 'generic inbox']);
+      const first3 = body.split('\n').slice(0, 3).join('\n');
+      if (GENERIC_SALUTATION_RE.test(first3)) flags.push(['red', 'no first name']);
+      if (NON_LATIN_RE.test(subj) || NON_LATIN_RE.test(body.substring(0, 500))) flags.push(['red', 'foreign script']);
+      if (PLACEHOLDER_RE.test(subj) || PLACEHOLDER_RE.test(body)) flags.push(['red', 'unrendered placeholder']);
+      if (!d.city_state) flags.push(['yel', 'no city/state']);
+      if (!d.hit_list_notes_present) flags.push(['yel', 'no hit list notes']);
+      if (!d.has_dapp_history) flags.push(['yel', 'no dapp history']);
+      if (d.hosts_circles) flags.push(['blu', 'hosts circles']);
+      return flags;
+    }
+
+    function severityRank(flags) {
+      if (flags.some(function (f) { return f[0] === 'red'; })) return 0;
+      if (flags.some(function (f) { return f[0] === 'yel'; })) return 1;
+      if (flags.some(function (f) { return f[0] === 'blu'; })) return 2;
+      return 3;
+    }
+
+    function sortKey(d) {
+      const r = severityRank(d._flags);
+      const aw = d.hosts_circles ? 0 : 1;
+      return r * 10 + aw;
+    }
+
+    function renderSummary(rows) {
+      const total = rows.length;
+      const red   = rows.filter(function (r) { return r._flags.some(function (f) { return f[0] === 'red'; }); }).length;
+      const yel   = rows.filter(function (r) { return !r._flags.some(function (f) { return f[0] === 'red'; }) && r._flags.some(function (f) { return f[0] === 'yel'; }); }).length;
+      const aw    = rows.filter(function (r) { return r.hosts_circles; }).length;
+      const clean = rows.filter(function (r) { return !r._flags.some(function (f) { return f[0] === 'red' || f[0] === 'yel'; }); }).length;
+      summaryEl.innerHTML =
+          '<div><b>' + total + '</b>pending</div>' +
+          '<div><b style="color:#d33">' + red + '</b>red flagged</div>' +
+          '<div><b style="color:#e90">' + yel + '</b>yellow only</div>' +
+          '<div><b style="color:#2a2">' + clean + '</b>clean</div>' +
+          '<div><b style="color:#28a">' + aw + '</b>Hosts Circles</div>';
+    }
+
+    function renderDraft(d) {
+      const flags = d._flags;
+      let cls = 'clean';
+      if (flags.some(function (f) { return f[0] === 'red'; })) cls = 'red';
+      else if (flags.some(function (f) { return f[0] === 'yel'; })) cls = 'yel';
+      else if (flags.some(function (f) { return f[0] === 'blu'; })) cls = 'blu';
+
+      const flagHtml = flags.map(function (f) {
+        return '<span class="flag f-' + f[0] + '">' + escapeHtml(f[1]) + '</span>';
+      }).join('');
+
+      const gmailLink = d.gmail_message_id
+          ? 'https://mail.google.com/mail/u/0/#drafts/' + encodeURIComponent(d.gmail_message_id)
+          : 'https://mail.google.com/mail/u/0/#label/AI%2FWarm-up';
+
+      return '' +
+        '<div class="draft ' + cls + '" data-draft-id="' + escapeHtml(d.gmail_draft_id) + '" id="d-' + escapeHtml(d.gmail_draft_id) + '">' +
+          '<div class="row1">' +
+            '<span class="recipient">' + escapeHtml(d.to_email || '(no email)') + '</span>' +
+            (d.shop_name ? '<span class="shop">' + escapeHtml(d.shop_name) + '</span>' : '') +
+            (d.city_state ? '<span class="city">' + escapeHtml(d.city_state) + '</span>' : '') +
+            (d.hosts_circles ? '<span class="aw">Hosts Circles</span>' : '') +
+          '</div>' +
+          '<div class="subject">' + escapeHtml(d.subject || '(no subject)') + '</div>' +
+          (flagHtml ? '<div class="flags">' + flagHtml + '</div>' : '') +
+          '<div class="actions">' +
+            '<button class="btn-send" type="button" data-act="send">Send</button>' +
+            '<a class="open-gmail" href="' + gmailLink + '" target="_blank" rel="noopener">Edit in Gmail</a>' +
+            '<span class="row-status" data-status></span>' +
+          '</div>' +
+          (d.body_preview
+              ? '<details><summary>Show body preview (≤500 chars)</summary><pre class="body">' + escapeHtml(d.body_preview) + '</pre></details>'
+              : '') +
+        '</div>';
+    }
+
+    let allDrafts = [];
+
+    async function loadQueue() {
+      refreshBtn.disabled = true;
+      setStatus('Loading queue…');
+      try {
+        const url = GAS_URL + '?action=getWarmupReviewQueue';
+        const resp = await fetch(url, { method: 'GET' });
+        if (!resp.ok) throw new Error('HTTP ' + resp.status);
+        const json = await resp.json();
+        if (json.status !== 'success') throw new Error(json.message || 'GAS error');
+        const data = json.data || {};
+        allDrafts = (data.drafts || []).map(function (d) {
+          d._flags = lintDraft(d);
+          return d;
+        });
+        allDrafts.sort(function (a, b) { return sortKey(a) - sortKey(b); });
+        renderSummary(allDrafts);
+        if (allDrafts.length === 0) {
+          listEl.innerHTML = '<div class="empty">No pending warm-up drafts.</div>';
+        } else {
+          listEl.innerHTML = allDrafts.map(renderDraft).join('');
+          attachSendHandlers();
+        }
+        lastFetchedEl.textContent = 'Last refreshed ' + new Date().toLocaleTimeString();
+        setStatus('');
+      } catch (e) {
+        setStatus('Failed to load queue: ' + e.message, 'error');
+      } finally {
+        refreshBtn.disabled = false;
+      }
+    }
+
+    function attachSendHandlers() {
+      Array.prototype.forEach.call(listEl.querySelectorAll('button[data-act="send"]'), function (btn) {
+        btn.addEventListener('click', function () { onSend(btn); });
+      });
+    }
+
+    async function onSend(btn) {
+      const card = btn.closest('.draft');
+      if (!card) return;
+      const draftId = card.getAttribute('data-draft-id');
+      const draft = allDrafts.find(function (d) { return d.gmail_draft_id === draftId; });
+      if (!draft) return;
+      const statusSpan = card.querySelector('[data-status]');
+      btn.disabled = true;
+      card.classList.add('sending');
+      statusSpan.textContent = 'Signing…';
+      statusSpan.classList.remove('error');
+
+      try {
+        const submittedAt = new Date().toISOString();
+        const plainText = [
+          EVENT_TAG,
+          '- Draft ID: ' + draftId,
+          '- Recipient: ' + (draft.to_email || ''),
+          '- Subject: ' + (draft.subject || '').replace(/\n/g, ' '),
+          '- Shop Name: ' + (draft.shop_name || ''),
+          '- Submitted At: ' + submittedAt,
+          '- Submission Source: ' + window.location.href,
+          '--------',
+        ].join('\n');
+
+        const keyObj = await window.crypto.subtle.importKey(
+            'pkcs8',
+            base64ToArrayBuffer(privateKey),
+            { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+            false,
+            ['sign']);
+        const sig = await window.crypto.subtle.sign(
+            'RSASSA-PKCS1-v1_5', keyObj, new TextEncoder().encode(plainText));
+        const requestHash = arrayBufferToBase64(sig);
+        const shareText = plainText +
+            '\n\nMy Digital Signature: ' + publicKey +
+            '\n\nRequest Transaction ID: ' + requestHash +
+            '\n\nThis submission was generated using ' + window.location.href +
+            '\n\nVerify submission here: https://dapp.truesight.me/verify_request.html';
+
+        statusSpan.textContent = 'Submitting…';
+        const formData = new FormData();
+        formData.append('text', shareText);
+        const resp = await fetch(EDGAR_SUBMIT, { method: 'POST', body: formData });
+        if (!resp.ok) {
+          const errText = await resp.text();
+          throw new Error('Edgar HTTP ' + resp.status + ': ' + errText.substring(0, 200));
+        }
+        // Edgar logs the event + fires the GAS webhook async. Optimistic
+        // remove from view: GmailApp.sendDraft idempotent; if it fails on
+        // GAS side, the draft survives and a refresh will re-show it.
+        statusSpan.textContent = 'Sent';
+        showToast('Sent — ' + (draft.shop_name || draft.to_email));
+        setTimeout(function () { card.classList.add('sent'); }, 600);
+        // Optional: re-pull the queue after 30s to confirm draft is gone.
+        setTimeout(loadQueue, 30000);
+      } catch (e) {
+        card.classList.remove('sending');
+        btn.disabled = false;
+        statusSpan.textContent = 'Failed: ' + e.message;
+        statusSpan.classList.add('error');
+        showToast('Send failed: ' + e.message, true);
+      }
+    }
+
+    refreshBtn.addEventListener('click', loadQueue);
+
+    // Boot — gate on operator role.
+    (function () {
+      if (!publicKey || !privateKey) {
+        setStatus('');
+        document.getElementById('gateContainer').innerHTML =
+            '<div style="padding:1rem; background:#fff8e1; border-left:4px solid #f0ad4e; border-radius:4px;">' +
+            'Sign in with your Digital Signature to use this page. ' +
+            '<a href="./digital_signature.html">Set up digital signature →</a></div>';
+        return;
+      }
+      window.DaoMembersCache.findByPublicKey(publicKey).then(function (lookup) {
+        if (!lookup || !lookup.contributor) {
+          setStatus('');
+          document.getElementById('gateContainer').innerHTML =
+              '<div style="padding:1rem; background:#fde; border-left:4px solid #c00; border-radius:4px;">' +
+              'Public key not found in DAO Members. Contact a governor to register.</div>';
+          return;
+        }
+        contributorName = lookup.contributor.name || '';
+        window.Permissions.requireRole({
+          action: ACTION_ROLE,
+          publicKey: publicKey,
+          denyContainerId: 'gateContainer',
+          onAllowed: function () {
+            setStatus('');
+            contentEl.style.display = 'block';
+            loadQueue();
+          },
+          onDenied: function () { setStatus(''); },
+        });
+      }).catch(function (err) {
+        setStatus('Permission check failed: ' + err.message, 'error');
+      });
+    })();
+  </script>
+  <script src="./js/dapp_footer_links.js?v=1"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Adds \`dapp/warmup_review.html\` — operator-facing mobile-first triage view for pending warm-up Gmail drafts. Replaces "open every draft in Gmail mobile, skim, send" with **scan red-first in DApp → tap Send → email ships from Gmail**.

## Architecture (matches \`dapp_permission_change\` pattern)
\`\`\`
DApp signs [WARMUP SEND EVENT] with operator RSA key
 → POST to Edgar /dao/submit_contribution
 → Edgar verifies sig + persists to Telegram Chat Logs
 → Edgar fires webhook ?action=apply_warmup_send to GAS
 → GAS WarmupSendHandler.gs verifies ACTIVE membership
     + GmailApp.getDraft(id).send()
 → email leaves operator's Gmail; Warmup Sends audit row appended
\`\`\`

## Page features
- \`Permissions.requireRole({action: 'warmup.send'})\` gate
- Reads pending queue from \`getWarmupReviewQueue\` (storesHitList GAS, ships in tokenomics #268) — **no extra Edgar route needed**
- 12 lint rules in vanilla JS, mirrors \`preview_warmup_drafts.py\`:
  - **red** — subject empty, body empty/short, fallback "your shop", generic \`info@\`/\`sales@\` inbox, "Hi there" salutation, foreign script, unrendered placeholder
  - **yellow** — no city/state, no Hit List notes, no DApp Remarks history (cold first touch)
  - **blue** — Hosts Circles=Yes (high-leverage prospect badge)
- Sort: red flagged first, then yellow-only, then clean — Hosts Circles floats to top within each tier
- "Edit in Gmail" deep-links use \`gmail_message_id\` (persisted upstream in go_to_market #107) so a single tap opens the draft on mobile
- Optimistic remove on Send + 30s re-fetch to confirm; toast on failure
- Mobile breakpoint @720px; 40px+ tap targets

\`menu.js\` + \`index.html\` link the new page under **Retail & field activity**.

## Companion PRs (all merged)
- treasury-cache ([\`warmup.send\` permission](https://github.com/TrueSightDAO/treasury-cache/pull/4))
- go_to_market ([gmail_message_id persistence](https://github.com/TrueSightDAO/go_to_market/pull/107))
- tokenomics ([GAS handlers](https://github.com/TrueSightDAO/tokenomics/pull/268))
- sentiment_importer ([Edgar dispatcher](https://github.com/TrueSightDAO/sentiment_importer/pull/1045)) — needs \`./deploy.sh\` before the page can ship sends

## Test plan
- [ ] After Edgar deploys: open page on phone, verify role gate
- [ ] Verify red-first sort + Hosts Circles badge surfacing
- [ ] Tap Send on a clean draft → email lands in recipient's inbox + draft disappears from queue
- [ ] Tap "Edit in Gmail" → deep-link opens the right draft
- [ ] Tap Send on a draft whose Gmail-side draft was already deleted → audit row records \`not_found_in_gmail\`, page shows error toast