### PR TITLE
chore(sw): bump cache version v7 → v8 to flush stale Outbound Review

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,6 @@
 importScripts('./routes.js');
 
-const CACHE_NAME = 'qr-scanner-cache-v7';
+const CACHE_NAME = 'qr-scanner-cache-v8';
 
 /**
  * Apps Script web apps + Edgar GAS proxy — must not use the Cache API or HTTP cache


### PR DESCRIPTION
## Summary
Bumps service worker \`CACHE_NAME\` from \`qr-scanner-cache-v7\` to \`v8\` to flush stale page content.

## Why
PR #202 shipped \`warmup_review.html\` without the standard logo + chrome. PR #203 added the logo, tab toggle, and filter chips. Browsers that loaded the page during the v202 window have the chromeless version in their service-worker cache. Bumping the cache name triggers the existing eviction logic in the SW activate handler (line 79) — every browser refetches on next load, no manual cache-clear needed.

## Test plan
- [ ] After merge + Pages deploy, open `dapp.truesight.me/warmup_review.html`. SW activates v8, evicts v7. Logo visible, tabs visible, filter chips visible.