### PR TITLE
fix(outbound-review): repair 4 stale references after single-API refactor

### DIFF
--- a/warmup_review.html
+++ b/warmup_review.html
@@ -376,19 +376,26 @@
     }
 
     function rerenderList() {
-      const drafts = (allDraftsByLabel && allDraftsByLabel[activeLabel]) || [];
+      const drafts = ((allDraftsByLabel && allDraftsByLabel[activeLabel]) || []).slice();
+      // Lint + sort once (lintDraft is idempotent; doesn't mutate beyond _flags).
+      drafts.forEach(function (d) { d._flags = lintDraft(d); });
+      drafts.sort(function (a, b) { return sortKey(a) - sortKey(b); });
+
       const filter = CHIP_FILTERS[activeChip] || CHIP_FILTERS.all;
-      const filtered = drafts.filter(function (d) { d._flags = lintDraft(d); return filter(d); });
-      // Re-render summary so the active chip highlight updates.
+      const filtered = drafts.filter(filter);
+      // Render the clickable chip summary (counts reflect the full active-tab cohort,
+      // not the filtered subset — that way chips can take you back to the full list).
       renderSummary(drafts);
+
       if (filtered.length === 0) {
         listEl.innerHTML = '<div class="empty">' +
-            (allDrafts.length === 0 ? 'No pending drafts.' : 'No drafts match this filter.') +
+            (drafts.length === 0 ? 'No pending drafts in this cohort.' : 'No drafts match this filter.') +
             '</div>';
       } else {
         listEl.innerHTML = filtered.map(renderDraft).join('');
         attachSendHandlers();
       }
+      lastFetchedEl.textContent = 'Last refreshed ' + new Date().toLocaleTimeString();
     }
 
     function renderDraft(d) {
@@ -458,29 +465,17 @@
     }
 
     function renderActiveTab() {
-      const drafts = (allDraftsByLabel[activeLabel] || []).slice();
-      const activeKey = activeLabel === 'AI/Follow-up' ? 'followup' : activeLabel === 'AI/Prospect Replied' ? 'prospect' : 'warmup';
+      // Update the active tab's badge from the cached cohort length (loadQueue
+      // already populated all three badges from data.counts, but this keeps
+      // the active one accurate after client-side filter changes).
+      const drafts = (allDraftsByLabel && allDraftsByLabel[activeLabel]) || [];
+      const activeKey = activeLabel === 'AI/Follow-up' ? 'followup'
+          : activeLabel === 'AI/Prospect Replied' ? 'prospect'
+          : 'warmup';
       const activeBadge = document.querySelector('[data-count="' + activeKey + '"]');
       if (activeBadge) activeBadge.textContent = String(drafts.length);
-
-      // Apply linter and sort
-      drafts.forEach(function (d) { d._flags = lintDraft(d); });
-      drafts.sort(function (a, b) { return sortKey(a) - sortKey(b); });
-
-      // Render list
-      const listEl = document.getElementById('draftList');
-      if (!drafts.length) {
-        listEl.innerHTML = '<div class="empty">No pending drafts in this cohort.</div>';
-        document.getElementById('summary').textContent = '';
-      } else {
-        let html = '';
-        for (let i = 0; i < drafts.length; i++) {
-          html += renderDraftCard(drafts[i]);
-        }
-        listEl.innerHTML = html;
-        document.getElementById('summary').textContent = drafts.length + ' draft' + (drafts.length !== 1 ? 's' : '') + ' pending review.';
-      }
-      lastFetchedEl.textContent = 'Last refreshed ' + new Date().toLocaleTimeString();
+      // Defer to rerenderList for the actual lint + sort + chip + draft rendering.
+      rerenderList();
     }
 
     async function loadQueue() {
@@ -537,7 +532,9 @@
       const card = btn.closest('.draft');
       if (!card) return;
       const draftId = card.getAttribute('data-draft-id');
-      const draft = allDrafts.find(function (d) { return d.gmail_draft_id === draftId; });
+      // Look up across the active cohort (Send buttons only render on the active tab).
+      const cohort = (allDraftsByLabel && allDraftsByLabel[activeLabel]) || [];
+      const draft = cohort.find(function (d) { return d.gmail_draft_id === draftId; });
       if (!draft) return;
       const statusSpan = card.querySelector('[data-status]');
       btn.disabled = true;


### PR DESCRIPTION
## Summary
\`commit 99d7fac\` refactored \`loadQueue()\` to fetch all three cohorts at once into \`allDraftsByLabel\`, but missed four spots that still referenced the old flat \`allDrafts\` variable + a never-defined \`renderDraftCard\`. Operator-visible symptoms today:

- \`/warmup_review.html#followup\` loaded but the follow-up cohort never rendered. Cause: \`renderActiveTab()\` called \`renderDraftCard(drafts[i])\` (line 478) — function doesn't exist. The \`ReferenceError\` killed the render flow before the list could populate.
- All three tab badges + summary chips failed to update. Same root cause: \`renderActiveTab\` threw before badges or summary repainted.
- Chip filtering broken. \`rerenderList\` line 386 referenced \`allDrafts.length\` (undefined → \`ReferenceError\` on chip click).
- Send button silently failed. Handler at line 535 referenced \`allDrafts.find(...)\` (undefined).

## Fixes
- **\`rerenderList\`**: sources drafts from \`allDraftsByLabel[activeLabel]\`; lint+sort once at the top; calls \`renderSummary(drafts)\` to draw the clickable chip summary (was previously being overwritten with plain text); empty-state copy distinguishes "no drafts in cohort" vs "no drafts match this filter".
- **\`renderActiveTab\`**: thin wrapper that updates the active tab badge then delegates to \`rerenderList\`. Drops the \`renderDraftCard\` typo and the plain-text summary that ate the chips.
- **\`onSend\`**: looks up the draft in \`allDraftsByLabel[activeLabel]\` instead of the dead \`allDrafts\`. Send buttons only render on the active tab, so a single-cohort lookup is sufficient.

## Test plan
- [x] JS syntax valid (\`new Function(...)\` parse passes).
- [x] \`grep "allDrafts\b\\|renderDraftCard"\` returns 0 hits.
- [ ] Operator opens \`/warmup_review.html#followup\` → follow-up tab is highlighted, badge shows count, list renders 2 follow-up drafts.
- [ ] Switching tabs updates active badge + repaints draft list + chips.
- [ ] Tap "red flagged" chip → list filters to red only; tap "All" → restores full list.
- [ ] Tap Send on a draft → POST fires (and once Edgar deploy lands, draft ships).

## Companion
- \`market_research\` — \`promote_warmup_replies()\` now applies the \`AI/Prospect Replied\` Gmail label to inbound threads (separate PR). One-shot backfill already ran for the 6 existing rows at that status.