### PR TITLE
feat(warmup_review): add full body expand and original reply display

### DIFF
--- a/warmup_review.html
+++ b/warmup_review.html
@@ -173,6 +173,9 @@
       font: 0.85rem ui-monospace, SFMono-Regular, Menlo, monospace;
       max-height: 360px; overflow-y: auto;
     }
+    pre.body.full { border-left: 3px solid #007bff; max-height: 600px; }
+    pre.body.reply { border-left: 3px solid #f0ad4e; background: #fffdf5; max-height: 400px; }
+    .no-full-body, .no-reply { font-size: 0.8rem; color: #999; font-style: italic; margin-top: 0.3rem; }
     .empty { text-align: center; padding: 2rem 0; color: #888; }
     .toast {
       position: fixed; bottom: 1rem; left: 50%; transform: translateX(-50%);
@@ -438,6 +441,12 @@
           (d.body_preview
               ? '<details><summary>Show body preview (≤500 chars)</summary><pre class="body">' + escapeHtml(d.body_preview) + '</pre></details>'
               : '') +
+          (d.body_full
+              ? '<details><summary>Expand full body</summary><pre class="body full">' + escapeHtml(d.body_full) + '</pre></details>'
+              : (d.body_preview ? '<div class="no-full-body">Full body not available (draft may have been sent or deleted)</div>' : '')) +
+          (d.prospect_reply_body
+              ? '<details><summary>Show original reply</summary><pre class="body reply">' + escapeHtml(d.prospect_reply_body) + '</pre></details>'
+              : (activeLabel === 'AI/Prospect Replied' ? '<div class="no-reply">Reply content not found in DApp Remarks</div>' : '')) +
         '</div>';
     }
 


### PR DESCRIPTION
DApp change: adds 'Expand full body' and 'Show original reply' toggles for reviewing Gmail drafts. GAS API v30 powers the new body_full and prospect_reply_body fields.