### PR TITLE
fix(warmup_review): show em-dash instead of 0 before drafts load

### DIFF
--- a/warmup_review.html
+++ b/warmup_review.html
@@ -218,13 +218,13 @@
     <div id="content" style="display: none;">
       <div class="tabs" role="tablist">
         <button class="tab-btn active" type="button" data-label="AI/Warm-up" role="tab" aria-selected="true">
-          Warm-ups <span class="badge" data-count="warmup">0</span>
+          Warm-ups <span class="badge" data-count="warmup">&mdash;</span>
         </button>
         <button class="tab-btn" type="button" data-label="AI/Follow-up" role="tab" aria-selected="false">
-          Follow-ups <span class="badge" data-count="followup">0</span>
+          Follow-ups <span class="badge" data-count="followup">&mdash;</span>
         </button>
         <button class="tab-btn" type="button" data-label="AI/Prospect Replied" role="tab" aria-selected="false">
-          Prospects <span class="badge" data-count="prospect">0</span>
+          Prospects <span class="badge" data-count="prospect">&mdash;</span>
         </button>
       </div>
       <div class="toolbar">


### PR DESCRIPTION
Tabs now show — instead of 0 when the page first renders, before the API call completes. JS still sets the real count when data arrives.