### PR TITLE
[autopilot] In chat.html, add a 1-line HTML comment right after the open

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -589,6 +589,7 @@
     </style>
 </head>
 <body>
+    <!-- autopilot fix_agent test: DRY_RUN decoupled 2026-05-06 -->
     <button class="session-toggle" id="session-toggle" title="Sessions">&#9776; <span class="badge" id="pending-badge">0</span></button>
     <div id="pending-inline-badge" style="display:none; position:fixed; top:0.5rem; left:4.5rem; z-index:1001; background:#fff3cd; border:1px solid #ffc107; border-radius:6px; padding:0.2rem 0.6rem; font-size:0.8rem; color:#856404; cursor:pointer; white-space:nowrap;"></div>
     <div id="session-panel">


### PR DESCRIPTION
## Autopilot Fix

**Issue:** In chat.html, add a 1-line HTML comment right after the opening <body> tag (before the <button class="session-toggle"> element): <!-- autopilot fix_agent test: DRY_RUN decoupled 2026-05-06 -->. Place it on its own line, indented the same as the surrounding elements (4 spaces). Do not change anything else in the file.

**Branch:** `autopilot/fix-1778112154`

---

This PR was generated by [truesight_autopilot](https://github.com/TrueSightDAO/truesight_autopilot). Please review before merging.