### PR TITLE
[autopilot] In dapp/routes.js, the async probe to script.google.com fire

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -75,6 +75,11 @@
   // Uses sessionStorage to guard against a reload loop if the probe itself
   // triggers a reload. On failure, flip localStorage to 'proxy' and reload.
   if (isWindow && mode === 'direct') {
+    // Skip probe on localhost — developer mode, no CORS to script.google.com.
+    var hostname = window.location.hostname;
+    if (hostname === 'localhost' || hostname === '127.0.0.1') {
+      // no-op: developer is running locally
+    } else {
     try {
       if (sessionStorage.getItem('routesProbed') !== 'true') {
         sessionStorage.setItem('routesProbed', 'true');

--- a/routes.js
+++ b/routes.js
@@ -110,5 +110,6 @@
     } catch (_) {
       // sessionStorage unavailable — skip probe.
     }
-  }
+    } // end else (non-localhost)
+  } // end if (isWindow && mode === 'direct')
 })(typeof self !== 'undefined' ? self : this);


### PR DESCRIPTION
## Autopilot Fix

**Issue:** In dapp/routes.js, the async probe to script.google.com fires on every page load in direct mode, including localhost. Since localhost cannot reach script.google.com (CORS/network), the probe always fails after 3 seconds and calls window.location.reload(). This creates an infinite reload loop on pages with query params like create_signature.html?em=...&vk=...

Fix: Add two guards before the probe fires:

1. **Localhost guard**: Skip the probe entirely when `window.location.hostname` is `'localhost'` or `'127.0.0.1'`. On localhost, the developer is working offline or behind a local server and doesn't need the probe — they can manually set `?route=proxy` if needed.

2. **ServiceWorker guard**: The existing `isWindow` check already handles this, but add an explicit comment and ensure `window.location` is only accessed after the `isWindow` guard (it already is, but make the localhost check sit inside the same block).

The fix is a simple early-return guard inserted right after the `if (isWindow && mode === 'direct')` line, before the sessionStorage check:

```js
// Skip probe on localhost — developer mode, no CORS to script.google.com
var hostname = window.location.hostname;
if (hostname === 'localhost' || hostname === '127.0.0.1') {
  // no-op: developer is running locally
}
```

This prevents the reload loop entirely when developing locally.

**Branch:** `autopilot/fix-1778113328`

---

This PR was generated by [truesight_autopilot](https://github.com/TrueSightDAO/truesight_autopilot). Please review before merging.