### PR TITLE
[autopilot] Fix "Loading your TDG holdings…" stuck state on chat.html

T

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -23,6 +23,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./menu.js?v=20260430"></script>
+    <script src="./scripts/dao_members_cache.js"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/edgar_payload_helper.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>

--- a/tdg_balance.js
+++ b/tdg_balance.js
@@ -95,11 +95,20 @@
             _source: 'github_cache'
           };
         })
-      : fetch(CACHE_URL, { cache: 'no-cache' })
-          .then(function(r) {
-            if (!r.ok) throw new Error('cache HTTP ' + r.status);
-            return r.json();
-          })
+      : (function() {
+            var controller = new AbortController();
+            var timeoutId = setTimeout(function() { controller.abort(); }, 5000);
+            return fetch(CACHE_URL, { cache: 'no-cache', signal: controller.signal })
+              .then(function(r) {
+                clearTimeout(timeoutId);
+                if (!r.ok) throw new Error('cache HTTP ' + r.status);
+                return r.json();
+              })
+              .catch(function(err) {
+                clearTimeout(timeoutId);
+                throw err;
+              });
+          })()
           .then(function(snapshot) {
             var daoTotals = (snapshot && snapshot.dao_totals) || {};
             var assetPerRight = parseFloat(daoTotals.asset_per_circulated_voting_right);


### PR DESCRIPTION
## Autopilot Fix

**Issue:** Fix "Loading your TDG holdings…" stuck state on chat.html

Two changes needed:

1. **Add dao_members_cache.js script to chat.html** — chat.html currently loads menu.js, tdg_balance.js, and edgar_payload_helper.js, but NOT scripts/dao_members_cache.js. This means tdg_balance.js can't use the shared session-memoized DaoMembersCache helper, forcing it to do its own inline fetch from GitHub raw. Add `<script src="./scripts/dao_members_cache.js"></script>` before tdg_balance.js so the shared cache is available.

2. **Add a timeout to the inline fetch fallback in tdg_balance.js** — the inline fetch in fetchFromCache uses `{ cache: 'no-cache' }` which forces revalidation with GitHub and can hang on slow connections or from localhost. Add a 5-second AbortController timeout so that if the GitHub raw fetch doesn't resolve quickly, it gracefully falls through to the GAS fallback instead of leaving "Loading your TDG holdings…" stuck indefinitely.

**Branch:** `autopilot/fix-1778114036`

---

This PR was generated by [truesight_autopilot](https://github.com/TrueSightDAO/truesight_autopilot). Please review before merging.