### PR TITLE
[autopilot] Fix tight spacing between the "+ New" button and the session

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -599,7 +599,7 @@
             <button id="close-panel-btn" style="background:none; border:none; font-size:1.2rem; cursor:pointer; padding:0 0.3rem; color:#666;">✕</button>
         </div>
         <button class="new-session-btn" id="new-session-btn">+ New</button>
-        <div id="pending-section" style="display:none; margin-bottom:0.5rem; border-bottom:1px solid #ddd; padding-bottom:0.5rem;">
+        <div id="pending-section" style="display:none; margin-bottom:0.5rem; margin-top:0.5rem; border-bottom:1px solid #ddd; padding-bottom:0.5rem;">
             <strong style="font-size:0.8rem; color:#dc3545;">⏳ Pending Approval</strong>
             <div id="pending-list" style="margin-top:0.25rem;"></div>
         </div>

--- a/chat.html
+++ b/chat.html
@@ -179,6 +179,7 @@
             padding: 0.2rem 0.5rem;
             font-size: 0.75rem;
             cursor: pointer;
+            margin-bottom: 0.75rem;
         }
         .new-session-btn:hover { background: #0056b3; }
         #status {

--- a/chat.html
+++ b/chat.html
@@ -124,7 +124,7 @@
             justify-content: space-between;
             align-items: center;
         }
-        #session-list { list-style: none; padding: 0; margin: 0; }
+        #session-list { list-style: none; padding: 0; margin: 0; margin-top: 0.5rem; }
         #session-list li {
             padding: 0.4rem 0.5rem;
             border-radius: 4px;


### PR DESCRIPTION
## Autopilot Fix

**Issue:** Fix tight spacing between the "+ New" button and the session list in the hamburger menu panel on chat.html.

The "+ New" button (`#new-session-btn`) has no bottom margin, and the session list (`#session-list`) has no top margin, so they sit too close together — especially when there's no pending-section visible.

Fix: Add `margin-bottom: 0.75rem` to `#new-session-btn` and/or `margin-top: 0.5rem` to `#session-list` in the CSS. This gives breathing room between the button and the first session item.

Also add a small margin-bottom to `#pending-section` when visible so it doesn't crowd the session list either.

**Branch:** `autopilot/fix-1778123965`

---

This PR was generated by [truesight_autopilot](https://github.com/TrueSightDAO/truesight_autopilot). Please review before merging.