### PR TITLE
[autopilot] Add session ID to URL hash so conversations can be shared/bo

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -654,9 +654,27 @@
         const LOCAL_CHAT_URL = 'http://localhost:8001';
         const DEFAULT_CHAT_URL = isLocalhost ? LOCAL_CHAT_URL : PRODUCTION_CHAT_URL;
 
-        // Session ID — persists across refreshes in the same tab, unique per tab
-        if (!sessionStorage.getItem('chatSessionId')) {
-            sessionStorage.setItem('chatSessionId', crypto.randomUUID ? crypto.randomUUID() : Date.now() + '-' + Math.random().toString(36).slice(2));
+        // Session ID — from URL hash, sessionStorage, or generated
+        function getSessionIdFromHash() {
+            var match = window.location.hash.match(/[#&]session=([^&]+)/);
+            return match ? match[1] : null;
+        }
+        function setSessionHash(id) {
+            var hash = '#session=' + id;
+            window.location.hash = hash;
+        }
+        var hashSessionId = getSessionIdFromHash();
+        if (hashSessionId) {
+            // URL hash takes precedence — persist to sessionStorage for backup
+            sessionStorage.setItem('chatSessionId', hashSessionId);
+        } else if (!sessionStorage.getItem('chatSessionId')) {
+            // No hash, no stored session — generate a new one
+            var newId = crypto.randomUUID ? crypto.randomUUID() : Date.now() + '-' + Math.random().toString(36).slice(2);
+            sessionStorage.setItem('chatSessionId', newId);
+            setSessionHash(newId);
+        } else {
+            // Restored from sessionStorage — sync hash
+            setSessionHash(sessionStorage.getItem('chatSessionId'));
         }
         const SESSION_ID = sessionStorage.getItem('chatSessionId');
 

--- a/chat.html
+++ b/chat.html
@@ -1440,6 +1440,7 @@
                 if (res.ok) {
                     var data = await res.json();
                     sessionStorage.setItem('chatSessionId', data.session_id);
+                    setSessionHash(data.session_id);
                     location.reload();
                 }
             } catch (e) {}

--- a/chat.html
+++ b/chat.html
@@ -1403,6 +1403,7 @@
                         nameSpan.style.flex = '1';
                         nameSpan.addEventListener('click', function() {
                             sessionStorage.setItem('chatSessionId', s.id);
+                            setSessionHash(s.id);
                             location.reload();
                         });
                         var renameBtn = document.createElement('button');


### PR DESCRIPTION
## Autopilot Fix

**Issue:** Add session ID to URL hash so conversations can be shared/bookmarked/resumed across tabs.

In chat.html, change the session ID management from sessionStorage-only to URL-hash-based:

1. **On page load** — Check `window.location.hash` for `#session=<uuid>`. If present, use that as the session ID instead of generating a new one. This lets someone paste a URL and pick up where they left off.

2. **On new session creation** — After creating a new session via the API, update `window.location.hash` to `#session=<new-id>` so the URL reflects the current session.

3. **On page unload / after each message** — Keep the hash in sync with the current session ID so copying the URL always captures the right session.

4. **Session ID generation** — Keep the existing fallback (crypto.randomUUID) but store it in the URL hash instead of just sessionStorage. Still keep sessionStorage as a backup for the initial load before the hash is set.

The session data is already server-persisted (loaded via GET /session), so the only missing piece is making the session ID survive URL copy/paste.

This is a small, focused change — just the session ID initialization logic in the `(function() { ... })()` block at the top of the chat.html script.

**Branch:** `autopilot/fix-1778124363`

---

This PR was generated by [truesight_autopilot](https://github.com/TrueSightDAO/truesight_autopilot). Please review before merging.