### PR TITLE
[autopilot] Fix pending approval items not being removed from hamburger 

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -1179,11 +1179,17 @@
         async function removePendingProposal(p) {
             var key = p.qr_code || p.title || '';
             if (key) {
+                var body;
+                if (p.qr_code) {
+                    body = JSON.stringify({ qr_code: key, action: 'approved' });
+                } else {
+                    body = JSON.stringify({ title: key, action: 'approved' });
+                }
                 try {
                     await fetch(API_BASE_URL + '/pending/resolve', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json', 'X-Public-Key': publicKey },
-                        body: JSON.stringify({ qr_code: key, action: 'approved' })
+                        body: body
                     });
                 } catch(e) {}
             }


### PR DESCRIPTION
## Autopilot Fix

**Issue:** Fix pending approval items not being removed from hamburger menu after clicking Approve in chat.

In chat.html, the `removePendingProposal` function sends the proposal's `qr_code` field to the server's `/pending/resolve` endpoint. But for merge PR proposals, there is no `qr_code` — only a `title`. The server needs a key to match against.

Fix: Change `removePendingProposal` to send the right key. For merge proposals (where `p.qr_code` is empty), use `p.title` as the key. The server-side `_resolve_pending` will be updated to match against both `qr_code` and `title` fields.

Change this:
```javascript
async function removePendingProposal(p) {
    var key = p.qr_code || p.title || '';
    if (key) {
        try {
            await fetch(API_BASE_URL + '/pending/resolve', {
                method: 'POST',
                headers: { 'Content-Type': 'application/json', 'X-Public-Key': publicKey },
                body: JSON.stringify({ qr_code: key, action: 'approved' })
            });
        } catch(e) {}
    }
    updatePendingUIFromServer();
}
```

The body sends `{qr_code: key}` but for merge proposals the key is actually a title. The server needs to match against both fields. This is fine as-is if the server also checks `title` — the key point is that `key` is correctly set to `p.title` when `p.qr_code` is empty.

**Branch:** `autopilot/fix-1778124713`

---

This PR was generated by [truesight_autopilot](https://github.com/TrueSightDAO/truesight_autopilot). Please review before merging.