### PR TITLE
[autopilot] ## Problem
When a user attaches an image file in chat.html, 

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -364,6 +364,13 @@
             font-size: 1.1rem;
             padding: 0 0.2rem;
         }
+        #attachment-preview .thumb {
+            max-width: 150px;
+            max-height: 100px;
+            border-radius: 4px;
+            border: 1px solid #ccc;
+            object-fit: cover;
+        }
         .btn {
             background-color: #007bff;
             color: white;

--- a/chat.html
+++ b/chat.html
@@ -1034,6 +1034,43 @@
         // Attachment state
         let pendingFile = null;
 
+        // Helper: convert a data URL to a File object
+        function dataURLtoFile(dataurl, filename) {
+            var arr = dataurl.split(','), mime = arr[0].match(/:(.*?);/)[1];
+            var bstr = atob(arr[1]), n = bstr.length, u8arr = new Uint8Array(n);
+            while (n--) { u8arr[n] = bstr.charCodeAt(n); }
+            return new File([u8arr], filename, { type: mime });
+        }
+
+        // Helper: create a thumbnail from an image file (maxWidth px wide), returns a promise
+        function createImageThumbnail(file, maxWidth) {
+            return new Promise(function(resolve, reject) {
+                var reader = new FileReader();
+                reader.onload = function(e) {
+                    var img = new Image();
+                    img.onload = function() {
+                        var canvas = document.createElement('canvas');
+                        var scale = Math.min(1, maxWidth / img.width);
+                        canvas.width = Math.round(img.width * scale);
+                        canvas.height = Math.round(img.height * scale);
+                        var ctx = canvas.getContext('2d');
+                        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+                        var dataUrl = canvas.toDataURL(file.type || 'image/png');
+                        resolve({
+                            thumbnailDataUrl: dataUrl,
+                            filename: file.name,
+                            size: file.size,
+                            type: file.type
+                        });
+                    };
+                    img.onerror = reject;
+                    img.src = e.target.result;
+                };
+                reader.onerror = reject;
+                reader.readAsDataURL(file);
+            });
+        }
+
         attachBtn.addEventListener('click', function() {
             fileInput.click();
         });
@@ -1045,12 +1082,43 @@
                 pendingFile = fileList[0];
                 attachFilename.textContent = fileList[0].name;
                 attachFilesize.textContent = '(' + (fileList[0].size / 1024).toFixed(1) + ' KB)';
+                // Generate thumbnail for images and persist to sessionStorage
+                if (fileList[0].type.startsWith('image/')) {
+                    createImageThumbnail(fileList[0], 150).then(function(thumbData) {
+                        // Show thumbnail in preview
+                        var existingThumb = attachPreview.querySelector('.thumb');
+                        if (existingThumb) existingThumb.remove();
+                        var thumbImg = document.createElement('img');
+                        thumbImg.className = 'thumb';
+                        thumbImg.src = thumbData.thumbnailDataUrl;
+                        thumbImg.alt = thumbData.filename;
+                        attachPreview.insertBefore(thumbImg, attachPreview.firstChild);
+                        // Persist to sessionStorage
+                        sessionStorage.setItem('pendingAttachment', JSON.stringify(thumbData));
+                    }).catch(function() {
+                        // If thumbnail fails, store without thumbnail
+                        sessionStorage.setItem('pendingAttachment', JSON.stringify({
+                            filename: fileList[0].name,
+                            size: fileList[0].size,
+                            type: fileList[0].type
+                        }));
+                    });
+                } else {
+                    // Non-image: store metadata without thumbnail
+                    sessionStorage.setItem('pendingAttachment', JSON.stringify({
+                        filename: fileList[0].name,
+                        size: fileList[0].size,
+                        type: fileList[0].type
+                    }));
+                }
             } else {
                 pendingFile = fileList; // Store as FileList
                 var totalSize = 0;
                 for (var i = 0; i < fileList.length; i++) totalSize += fileList[i].size;
                 attachFilename.textContent = fileList.length + ' files selected';
                 attachFilesize.textContent = '(' + (totalSize / 1024).toFixed(1) + ' KB total)';
+                // For multiple files, clear any stored single-file attachment
+                sessionStorage.removeItem('pendingAttachment');
             }
             attachPreview.style.display = 'flex';
         });
@@ -1059,6 +1127,7 @@
             pendingFile = null;
             fileInput.value = '';
             attachPreview.style.display = 'none';
+            sessionStorage.removeItem('pendingAttachment');
         });
 
         async function readSSEStream(res, ensureBotMessage, botTextDiv, fullResponse, botMsgDiv) {

--- a/chat.html
+++ b/chat.html
@@ -1302,6 +1302,7 @@
                     pendingFile = null;
                     fileInput.value = '';
                     attachPreview.style.display = 'none';
+                    sessionStorage.removeItem('pendingAttachment');
 
                     res = await fetch(CHAT_API_URL + '/upload', {
                         method: 'POST',

--- a/chat.html
+++ b/chat.html
@@ -1569,6 +1569,38 @@
                 authPromptEl.style.display = 'none';
                 chatUiEl.style.display = 'flex';
                 restoreSession();
+                // Restore pending attachment from sessionStorage (survives page refresh)
+                (function() {
+                    var stored = sessionStorage.getItem('pendingAttachment');
+                    if (stored) {
+                        try {
+                            var data = JSON.parse(stored);
+                            if (data.thumbnailDataUrl) {
+                                // Image with thumbnail — reconstruct File and show preview
+                                var restoredFile = dataURLtoFile(data.thumbnailDataUrl, data.filename);
+                                pendingFile = restoredFile;
+                                attachFilename.textContent = data.filename;
+                                attachFilesize.textContent = '(' + (data.size / 1024).toFixed(1) + ' KB)';
+                                var thumbImg = document.createElement('img');
+                                thumbImg.className = 'thumb';
+                                thumbImg.src = data.thumbnailDataUrl;
+                                thumbImg.alt = data.filename;
+                                attachPreview.insertBefore(thumbImg, attachPreview.firstChild);
+                                attachPreview.style.display = 'flex';
+                            } else if (data.filename) {
+                                // Non-image file — show filename only (can't reconstruct File without data)
+                                attachFilename.textContent = data.filename;
+                                attachFilesize.textContent = '(' + (data.size / 1024).toFixed(1) + ' KB)';
+                                attachPreview.style.display = 'flex';
+                                // We can't fully restore the File object for non-images from metadata alone,
+                                // but we show the preview so the user knows what was attached.
+                                // They'll need to re-attach the file to send it.
+                            }
+                        } catch(e) {
+                            sessionStorage.removeItem('pendingAttachment');
+                        }
+                    }
+                })();
             }
         } catch(e) {
             messagesEl.innerHTML = '<div class=\"message bot\"><div class=\"text\">Error loading chat: ' + e.message + '</div></div>';


### PR DESCRIPTION
## Autopilot Fix

**Issue:** ## Problem
When a user attaches an image file in chat.html, the attachment preview shows only the filename and size — no thumbnail. Worse, if the page is refreshed (accidental navigation, browser refresh), the pending attachment is completely lost because it's only stored in a JavaScript variable (`pendingFile`).

## Required Changes

### 1. Add thumbnail rendering in the attachment preview area
When a user attaches an image file, generate a thumbnail (max 150px wide) and display it inline in `#attachment-preview` alongside the filename. For non-image files, show a generic file icon.

### 2. Persist pending attachments in sessionStorage
When a file is attached via `fileInput.change`:
- For images: read the file as a base64 data URL using FileReader, create a thumbnail (canvas resize to max 150px width), and store `{ thumbnailDataUrl, filename, size, type }` in `sessionStorage.setItem('pendingAttachment', JSON.stringify(...))`
- For non-images: store filename, size, type without thumbnail data

### 3. Restore pending attachments on page load
In the initialization code (around the `restoreSession` call or right after), check `sessionStorage.getItem('pendingAttachment')`. If found:
- Parse the stored data
- Reconstruct a `File` object from the base64 data (using `dataURLtoFile` helper or `Blob`)
- Set `pendingFile` to the restored File
- Show the thumbnail and filename in `#attachment-preview`
- This way, if the user refreshes the page, the attachment survives

### 4. Clear sessionStorage on send and remove
- In `removeAttach.click` handler: add `sessionStorage.removeItem('pendingAttachment')`
- In `sendMessage` (when `hasFile` is true, right after `pendingFile = null`): add `sessionStorage.removeItem('pendingAttachment')`

### 5. Add a helper function `dataURLtoFile(dataurl, filename)` to convert base64 back to a File object

## Implementation Details

The changes are all within the `<script>` block of chat.html. No new external dependencies needed — use the built-in `FileReader` and `Canvas` APIs.

### Key code locations:
- **~line 450**: `fileInput.addEventListener('change', ...)` — add thumbnail generation + sessionStorage save
- **~line 465**: `removeAttach.addEventListener('click', ...)` — add sessionStorage.removeItem
- **~line 470**: `sendMessage()` function — add sessionStorage.removeItem after clearing pendingFile
- **~line 700**: `restoreSession()` or init area — add sessionStorage restore logic
- **New**: `dataURLtoFile` helper function
- **New**: `createImageThumbnail(file, maxWidth)` helper function that returns a promise resolving to `{ dataUrl, filename, size, type }`

### CSS addition
Add a style for the thumbnail image inside `#attachment-preview`:
```css
#attachment-preview .thumb { max-width: 150px; max-height: 100px; border-radius: 4px; border: 1px solid #ccc; object-fit: cover; }
```

Make targeted, minimal edits — don't restructure the file.

**Branch:** `autopilot/fix-1778128432`

---

This PR was generated by [truesight_autopilot](https://github.com/TrueSightDAO/truesight_autopilot). Please review before merging.