### PR TITLE
fix(currency-conversion): add offchain (Main Ledger) option + dynamic currency datalist

### DIFF
--- a/currency_conversion.html
+++ b/currency_conversion.html
@@ -250,21 +250,7 @@
                     <input type="number" id="targetAmountInput" min="0.00000001" step="any" placeholder="Amount received (e.g. 4985.00)" disabled>
                 </div>
                 <div class="help-text">The amount that ARRIVED in this currency's account, as shown on the receipt.</div>
-                <datalist id="commonCurrencies">
-                    <option value="USD">
-                    <option value="BRL">
-                    <option value="EUR">
-                    <option value="GBP">
-                    <option value="AUD">
-                    <option value="SGD">
-                    <option value="MYR">
-                    <option value="CAD">
-                    <option value="CNY">
-                    <option value="JPY">
-                    <option value="HKD">
-                    <option value="MXN">
-                    <option value="ARS">
-                </datalist>
+                <datalist id="commonCurrencies"></datalist>
             </div>
 
             <div class="form-row">
@@ -356,6 +342,20 @@
                 const ledgers = await response.json();
 
                 ledgerSelect.innerHTML = '<option value="">Select a ledger</option>';
+
+                // Default offchain (Main Ledger) option — matches report_dao_expenses.html.
+                // Carries an empty ledger URL; submitReport translates this to
+                // "Ledger: offchain" with no URL in the signed payload. Note the
+                // GAS validateManagedLedger() currently rejects offchain — this option
+                // is here for UX parity; pick a managed AGL ledger if you want the
+                // GAS to actually book the double-entry today.
+                const offchainOpt = document.createElement('option');
+                offchainOpt.value = 'offchain';
+                offchainOpt.textContent = 'offchain (Main Ledger - Default)';
+                offchainOpt.dataset.ledgerName = 'offchain';
+                offchainOpt.dataset.ledgerUrl = '';
+                ledgerSelect.appendChild(offchainOpt);
+
                 (ledgers || []).forEach(ledger => {
                     const option = document.createElement('option');
                     option.value = ledger.ledger_url;
@@ -378,6 +378,31 @@
             } catch (error) {
                 console.error('Error loading ledgers:', error);
                 ledgerSelect.innerHTML = '<option value="">Error loading ledgers</option>';
+            }
+        }
+
+        // Canonical currency list lives in TrueSightDAO/agroverse-inventory/currencies.json
+        // (rewritten by repackaging-currency-ingest GAS — see
+        // agentic_ai_context/LEDGER_CONVERSION_AND_REPACKAGING.md). It's a flat array
+        // mixing fiat names (e.g. "Brazilian Reis"), product SKUs, and equipment;
+        // the user picks whatever matches their actual conversion. The free-text
+        // input means a missing currency can still be typed by hand.
+        const CURRENCIES_JSON_URL = 'https://raw.githubusercontent.com/TrueSightDAO/agroverse-inventory/main/currencies.json';
+
+        async function loadCurrencies() {
+            const datalist = document.getElementById('commonCurrencies');
+            try {
+                const res = await fetch(CURRENCIES_JSON_URL, { cache: 'no-cache' });
+                const data = await res.json();
+                const names = (Array.isArray(data) ? data : (data.currencies || []))
+                    .map(s => String(s).trim())
+                    .filter(Boolean)
+                    .sort((a, b) => a.localeCompare(b));
+                datalist.innerHTML = names.map(n => `<option value="${n.replace(/"/g, '&quot;')}">`).join('');
+                console.log(`[currencies] loaded ${names.length} from agroverse-inventory/currencies.json`);
+            } catch (err) {
+                console.error('Error loading currencies.json — falling back to no datalist (free-text still works):', err);
+                datalist.innerHTML = '';
             }
         }
 
@@ -446,9 +471,13 @@
                 const selectedOption = ledgerSelect.options[ledgerSelect.selectedIndex];
                 const ledgerName = selectedOption.dataset.ledgerName;
                 const ledgerUrl = selectedOption.dataset.ledgerUrl;
-                ledgerLinkAnchor.href = ledgerUrl;
-                ledgerLinkAnchor.textContent = `View ${ledgerName} Ledger →`;
-                ledgerLink.style.display = 'block';
+                if (ledgerUrl) {
+                    ledgerLinkAnchor.href = ledgerUrl;
+                    ledgerLinkAnchor.textContent = `View ${ledgerName} Ledger →`;
+                    ledgerLink.style.display = 'block';
+                } else {
+                    ledgerLink.style.display = 'none';
+                }
             } else {
                 ledgerLink.style.display = 'none';
             }
@@ -615,7 +644,10 @@
 
             const selectedLedger = ledgerSelect.options[ledgerSelect.selectedIndex];
             const ledgerName = (selectedLedger.dataset.ledgerName || selectedLedger.textContent).trim();
-            const ledgerUrl = ledgerSelect.value;
+            // Offchain (Main Ledger) carries an empty ledger URL — emit empty string in
+            // the payload (not "offchain") so the receiving GAS sees no URL and routes
+            // accordingly. Managed AGL ledgers carry their actual /edit URL as the value.
+            const ledgerUrl = (ledgerSelect.value === 'offchain' || !selectedLedger.dataset.ledgerUrl) ? '' : ledgerSelect.value;
 
             const managerSelect = document.getElementById('managerSelect');
             const managerName = (managerSelect.value || '').trim();
@@ -728,7 +760,7 @@
 
             statusElement.textContent = 'Loading ledger options…';
             statusElement.className = 'loading fade-in';
-            await Promise.all([loadLedgers(), loadManagers()]);
+            await Promise.all([loadLedgers(), loadManagers(), loadCurrencies()]);
 
             statusElement.textContent = '';
             statusElement.className = '';

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,6 @@
 importScripts('./routes.js');
 
-const CACHE_NAME = 'qr-scanner-cache-v10';
+const CACHE_NAME = 'qr-scanner-cache-v11';
 
 /**
  * Apps Script web apps + Edgar GAS proxy — must not use the Cache API or HTTP cache


### PR DESCRIPTION
## Summary

Two issues Gary caught during the first real submission attempt:

1. **Default `offchain (Main Ledger)` option was missing** from the ledger picker — present in `report_dao_expenses.html` but not here. Adding it for UX parity.

   **Caveat:** the receiving GAS `validateManagedLedger()` currently rejects offchain (only managed AGL ledgers have a 6-column `Transactions` tab to route into). Picking offchain today will land the `[CURRENCY CONVERSION EVENT]` in `Telegram Chat Logs` but the intake row will go FAILED. Inline comment explains this. Extending the GAS to handle offchain is a separate concern; the Main Ledger's `offchain transactions` tab has 5 columns with no Currency column, so the double-entry schema doesn't fit cleanly.

2. **Source/target currency datalist was hardcoded** with ~13 ISO codes (USD, BRL, EUR, …). Replaced with a dynamic fetch of the canonical list at:

   ```
   https://raw.githubusercontent.com/TrueSightDAO/agroverse-inventory/main/currencies.json
   ```

   That's the same file the repackaging-currency-ingest GAS rewrites — see `agentic_ai_context/LEDGER_CONVERSION_AND_REPACKAGING.md`. The list mixes fiat names ("Brazilian Reis"), product SKUs, and equipment; the user picks whatever matches their actual conversion. Free-text input means anything missing can still be typed by hand.

## Plumbing details

- `loadCurrencies()` runs in parallel with `loadLedgers` + `loadManagers` on page boot; failure to fetch falls back gracefully (empty datalist, free-text still works).
- `updateLedgerLink` hides the "View Ledger →" anchor when the picked ledger has no URL (the offchain case).
- `submitReport` translates `ledgerSelect.value === "offchain"` → empty `ledgerUrl` in the signed payload (so the receiving GAS can route by presence/absence of URL, matching how `report_dao_expenses.html` behaves).
- Service worker `CACHE_NAME` bumped `v10 → v11` so the updated HTML actually reaches users.

## Test plan

- [ ] Hard refresh `currency_conversion.html` → ledger dropdown has `offchain (Main Ledger - Default)` as the first option above the managed AGL ledgers.
- [ ] Source/target currency inputs now show autocomplete from the full agroverse-inventory list (~hundreds of entries including "Brazilian Reis", "USD", "EUR", various SKUs).
- [ ] Picking `offchain (Main Ledger)` hides the "View Ledger →" anchor (no URL).
- [ ] Submitting with `offchain` lands the event in Telegram Chat Logs but goes FAILED on intake (until GAS is extended to route offchain) — flag as expected and a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)