### PR TITLE
warmup_review: All correspondence link per draft card

### DIFF
--- a/warmup_review.html
+++ b/warmup_review.html
@@ -484,6 +484,7 @@
           '<div class="actions">' +
             '<button class="btn-send" type="button" data-act="send">Send</button>' +
             '<a class="open-gmail" href="' + gmailLink + '" target="_blank" rel="noopener">Edit in Gmail</a>' +
+            (d.to_email ? '<a class="open-gmail" href="https://mail.google.com/mail/u/0/#search/' + encodeURIComponent(d.to_email) + '" target="_blank" rel="noopener" title="Open Gmail search for all threads with this recipient">All correspondence</a>' : '') +
             '<span class="row-status" data-status></span>' +
           '</div>' +
           (function () {


### PR DESCRIPTION
## Summary
- Adds an "All correspondence" link next to "Edit in Gmail" on each draft card.
- Opens Gmail's `#search/{to_email}` so the reviewer can see every prior thread with that recipient in one click.
- Useful for sanity-checking draft framing against earlier correspondence without leaving the review flow.

## Test plan
- [ ] Open https://dapp.truesight.me/warmup_review.html#followup
- [ ] Click "All correspondence" on a card → Gmail opens to a search of all threads with the recipient
- [ ] Cards without a `to_email` show no link (no broken anchor)