### PR TITLE
warmup_review: pin draft id in URL on Gmail-link clicks

### DIFF
--- a/warmup_review.html
+++ b/warmup_review.html
@@ -418,16 +418,21 @@
       Array.prototype.forEach.call(listEl.querySelectorAll('.draft'), function (card) {
         const id = card.getAttribute('data-draft-id');
         if (!id) return;
+        function focusThisCard() {
+          focusedDraftId = id;
+          writeHash();
+          // Drop the highlight ring once the user is interacting — they no
+          // longer need the "this is the one" hint.
+          card.classList.remove('deeplinked');
+        }
         Array.prototype.forEach.call(card.querySelectorAll('details'), function (det) {
-          det.addEventListener('toggle', function () {
-            if (det.open) {
-              focusedDraftId = id;
-              writeHash();
-              // Drop the highlight ring once the user is interacting — they no
-              // longer need the "this is the one" hint.
-              card.classList.remove('deeplinked');
-            }
-          });
+          det.addEventListener('toggle', function () { if (det.open) focusThisCard(); });
+        });
+        // Clicking either Gmail link should also pin the draft id in the URL —
+        // user might want to grab the URL right after jumping to Gmail without
+        // having expanded any details panel first.
+        Array.prototype.forEach.call(card.querySelectorAll('.open-gmail'), function (a) {
+          a.addEventListener('click', focusThisCard);
         });
       });
     }


### PR DESCRIPTION
## Summary
- Clicking "Edit in Gmail" or "All correspondence" now pins that card's `gmail_draft_id` in the URL hash (`#tab/d-{id}`), same effect as opening a `<details>` panel.
- Closes the gap where a reviewer jumping to Gmail before expanding anything couldn't copy a draft-specific URL.

## Test plan
- [ ] Open https://dapp.truesight.me/warmup_review.html#followup
- [ ] Without expanding anything, click "Edit in Gmail" on a card → URL bar updates to `#followup/d-r...` before Gmail opens
- [ ] Same for "All correspondence"