### PR TITLE
DApp: Facebook-style red notification badge for action items

### DIFF
--- a/batch_qr_generator.html
+++ b/batch_qr_generator.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
     
     <style>

--- a/chat.html
+++ b/chat.html
@@ -22,7 +22,7 @@
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/edgar_payload_helper.js"></script>

--- a/create_proposal.html
+++ b/create_proposal.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         * {

--- a/create_signature.html
+++ b/create_signature.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
   
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260510"></script>
+  <script src="./menu.js?v=20260512a"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/edgar_payload_helper.js"></script>

--- a/currency_conversion.html
+++ b/currency_conversion.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./js/treasury_cache.js"></script>
 
@@ -103,10 +103,46 @@
             cursor: not-allowed;
         }
         textarea { resize: none; min-height: 80px; }
+        /* Stack the currency picker on its own row above the amount so long
+           SKU / packaging names (e.g. "8 Ounce Package Kraft Pouch
+           CP340993268BR - Switzerland") fit without ellipsis. Same one-column
+           shape as the inventory-movement page's pickers. */
         .currency-pair {
             display: grid;
-            grid-template-columns: 1fr 1.5fr;
+            grid-template-columns: 1fr;
             gap: 0.5rem;
+        }
+        /* Currency combobox — replaces native <datalist> for a usable
+           type-or-pick experience. Shows full list on focus, filters as you
+           type, supports keyboard nav (↑/↓/Enter/Esc), and still allows
+           free-text entries that aren't in the list. */
+        .combobox { position: relative; }
+        .combobox input { padding-right: 2.2rem; }
+        .combobox-toggle {
+            position: absolute; right: 0.4rem; top: 50%;
+            transform: translateY(-50%);
+            background: none; border: none; color: #666; cursor: pointer;
+            font-size: 0.85rem; padding: 0.3rem;
+            line-height: 1;
+        }
+        .combobox-toggle:hover { color: #000; }
+        .combobox-list {
+            position: absolute; top: calc(100% + 2px); left: 0; right: 0;
+            background: white; border: 1px solid #bbb; border-radius: 4px;
+            max-height: 280px; overflow-y: auto;
+            z-index: 1000; margin: 0; padding: 0; list-style: none;
+            box-shadow: 0 4px 14px rgba(0,0,0,0.12);
+        }
+        .combobox-list[hidden] { display: none; }
+        .combobox-list li {
+            padding: 0.5rem 0.75rem; cursor: pointer; font-size: 0.92rem;
+            border-bottom: 1px solid #f0f0f0;
+        }
+        .combobox-list li:last-child { border-bottom: none; }
+        .combobox-list li.active, .combobox-list li:hover { background: #eef5ff; }
+        .combobox-list li.empty {
+            color: #999; cursor: default; font-style: italic;
+            background: none;
         }
         .rate-display {
             background: #eef5ff;
@@ -131,6 +167,7 @@
             width: 100%;
             max-width: 300px;
         }
+        #submitButton { display: block; }
         button:hover { background-color: #0056b3; transform: scale(1.02); }
         button:active { transform: scale(0.98); }
         button:disabled { background-color: #cccccc; cursor: not-allowed; transform: none; }
@@ -176,7 +213,7 @@
             }
             button { padding: 0.8rem 1.5rem; font-size: 0.95rem; }
             .paste-area { padding: 1.5rem; }
-            .currency-pair { grid-template-columns: 1fr; }
+            /* (already single-column desktop & mobile) */
         }
     </style>
 </head>
@@ -196,23 +233,6 @@
         <p id="status" class="fade-in">Verifying your digital signature…</p>
 
         <div id="info" style="display: none;">
-            <div class="form-row">
-                <label for="inputMethod">Conversion Receipt:</label>
-                <select id="inputMethod">
-                    <option value="upload" selected>Upload File or Image</option>
-                    <option value="camera">Use Camera</option>
-                </select>
-            </div>
-            <div class="form-row" id="upload-section" style="display: none;">
-                <label>Upload Receipt (Wise / Rendimento / bank statement):</label>
-                <div id="paste-area" class="paste-area">Click to select or paste (Ctrl+V) a file or image</div>
-            </div>
-            <div id="video-holder">
-                <video id="video" width="400" height="300" style="margin-bottom: 20px;" autoplay playsinline muted></video>
-                <button id="capture-btn" style="display: none;">Capture Photo</button>
-            </div>
-            <img id="uploaded-file-preview" style="display: none;" alt="Uploaded File Preview">
-
             <div class="form-row">
                 <label for="ledgerSelect">Managed Ledger:</label>
                 <select id="ledgerSelect" disabled>
@@ -237,7 +257,11 @@
             <div class="form-row">
                 <label>Source (currency you're spending):</label>
                 <div class="currency-pair">
-                    <input type="text" id="sourceCurrencyInput" list="commonCurrencies" placeholder="USD" maxlength="12" disabled autocapitalize="characters">
+                    <div class="combobox">
+                        <input type="text" id="sourceCurrencyInput" placeholder="Type or pick — e.g. USD" autocomplete="off" disabled>
+                        <button type="button" class="combobox-toggle" tabindex="-1" aria-label="Show options">▾</button>
+                        <ul class="combobox-list" role="listbox" hidden></ul>
+                    </div>
                     <input type="number" id="sourceAmountInput" min="0.00000001" step="any" placeholder="Amount out (e.g. 1000.00)" disabled>
                 </div>
                 <div class="help-text">The amount that LEFT this currency's account, as shown on the receipt (includes any provider fee).</div>
@@ -246,11 +270,14 @@
             <div class="form-row">
                 <label>Target (currency you received):</label>
                 <div class="currency-pair">
-                    <input type="text" id="targetCurrencyInput" list="commonCurrencies" placeholder="BRL" maxlength="12" disabled autocapitalize="characters">
+                    <div class="combobox">
+                        <input type="text" id="targetCurrencyInput" placeholder="Type or pick — e.g. BRL" autocomplete="off" disabled>
+                        <button type="button" class="combobox-toggle" tabindex="-1" aria-label="Show options">▾</button>
+                        <ul class="combobox-list" role="listbox" hidden></ul>
+                    </div>
                     <input type="number" id="targetAmountInput" min="0.00000001" step="any" placeholder="Amount received (e.g. 4985.00)" disabled>
                 </div>
                 <div class="help-text">The amount that ARRIVED in this currency's account, as shown on the receipt.</div>
-                <datalist id="commonCurrencies"></datalist>
             </div>
 
             <div class="form-row">
@@ -265,9 +292,26 @@
 
             <div class="form-row">
                 <label for="descriptionInput">Description:</label>
-                <textarea id="descriptionInput" maxlength="500" placeholder="e.g. Wise transfer USD→BRL to Rendimento, in preparation for Bico Duro May payout" disabled></textarea>
+                <textarea id="descriptionInput" maxlength="500" placeholder="e.g. Wise transfer USD→BRL to Rendimento. Paste a receipt image here and it will auto-attach below." disabled></textarea>
                 <div class="char-count"><span id="charCount">0</span>/500 characters</div>
             </div>
+
+            <div class="form-row">
+                <label for="inputMethod">Conversion Receipt:</label>
+                <select id="inputMethod">
+                    <option value="upload" selected>Upload File or Image</option>
+                    <option value="camera">Use Camera</option>
+                </select>
+            </div>
+            <div class="form-row" id="upload-section" style="display: none;">
+                <label>Upload Receipt (Wise / Rendimento / bank statement):</label>
+                <div id="paste-area" class="paste-area">Click to select or paste (Ctrl+V) a file or image — or paste an image into the Description above</div>
+            </div>
+            <div id="video-holder">
+                <video id="video" width="400" height="300" style="margin-bottom: 20px;" autoplay playsinline muted></video>
+                <button id="capture-btn" style="display: none;">Capture Photo</button>
+            </div>
+            <img id="uploaded-file-preview" style="display: none;" alt="Uploaded File Preview">
 
             <div class="form-row">
                 <div class="info-box">
@@ -389,21 +433,108 @@
         // input means a missing currency can still be typed by hand.
         const CURRENCIES_JSON_URL = 'https://raw.githubusercontent.com/TrueSightDAO/agroverse-inventory/main/currencies.json';
 
+        // In-memory option list used by both currency comboboxes.
+        let CURRENCY_OPTIONS = [];
+
         async function loadCurrencies() {
-            const datalist = document.getElementById('commonCurrencies');
             try {
                 const res = await fetch(CURRENCIES_JSON_URL, { cache: 'no-cache' });
                 const data = await res.json();
-                const names = (Array.isArray(data) ? data : (data.currencies || []))
+                CURRENCY_OPTIONS = (Array.isArray(data) ? data : (data.currencies || []))
                     .map(s => String(s).trim())
                     .filter(Boolean)
                     .sort((a, b) => a.localeCompare(b));
-                datalist.innerHTML = names.map(n => `<option value="${n.replace(/"/g, '&quot;')}">`).join('');
-                console.log(`[currencies] loaded ${names.length} from agroverse-inventory/currencies.json`);
+                console.log(`[currencies] loaded ${CURRENCY_OPTIONS.length} from agroverse-inventory/currencies.json`);
             } catch (err) {
-                console.error('Error loading currencies.json — falling back to no datalist (free-text still works):', err);
-                datalist.innerHTML = '';
+                console.error('Error loading currencies.json — combobox will show empty list (free-text still works):', err);
+                CURRENCY_OPTIONS = [];
             }
+        }
+
+        // Wire a single combobox: shows full option list on focus, filters as
+        // you type, supports ↑/↓/Enter/Esc, and still accepts free-text values
+        // that aren't in the list (so a missing fiat / SKU can be typed by hand).
+        function wireCurrencyCombobox(inputId) {
+            const input = document.getElementById(inputId);
+            const wrap = input.closest('.combobox');
+            const list = wrap.querySelector('.combobox-list');
+            const toggle = wrap.querySelector('.combobox-toggle');
+            let activeIdx = -1;
+
+            function escapeHtml(s) {
+                return String(s).replace(/[&<>"']/g, c => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]));
+            }
+            function render(filter) {
+                const q = (filter || '').trim().toLowerCase();
+                const all = CURRENCY_OPTIONS || [];
+                const filtered = q ? all.filter(c => c.toLowerCase().includes(q)) : all.slice();
+                if (filtered.length === 0) {
+                    list.innerHTML = '<li class="empty">No match — your typed value will be used as-is</li>';
+                } else {
+                    list.innerHTML = filtered.map(c =>
+                        `<li role="option" data-val="${escapeHtml(c)}">${escapeHtml(c)}</li>`
+                    ).join('');
+                }
+                activeIdx = -1;
+            }
+            function open() {
+                if (input.disabled) return;
+                render(input.value);
+                list.hidden = false;
+            }
+            function close() {
+                list.hidden = true;
+                activeIdx = -1;
+            }
+            function setActive(i) {
+                const items = list.querySelectorAll('li[data-val]');
+                if (!items.length) return;
+                activeIdx = Math.max(0, Math.min(i, items.length - 1));
+                items.forEach((el, idx) => el.classList.toggle('active', idx === activeIdx));
+                items[activeIdx].scrollIntoView({ block: 'nearest' });
+            }
+            function commit(val) {
+                input.value = val;
+                input.dispatchEvent(new Event('input', { bubbles: true }));
+                input.dispatchEvent(new Event('change', { bubbles: true }));
+                close();
+            }
+
+            input.addEventListener('focus', open);
+            input.addEventListener('input', () => { render(input.value); list.hidden = false; });
+            input.addEventListener('keydown', (e) => {
+                const items = list.querySelectorAll('li[data-val]');
+                if (e.key === 'ArrowDown') {
+                    e.preventDefault();
+                    if (list.hidden) open();
+                    else setActive(activeIdx + 1);
+                } else if (e.key === 'ArrowUp') {
+                    e.preventDefault();
+                    setActive(activeIdx - 1);
+                } else if (e.key === 'Enter') {
+                    if (!list.hidden && activeIdx >= 0 && items[activeIdx]) {
+                        e.preventDefault();
+                        commit(items[activeIdx].dataset.val);
+                    }
+                } else if (e.key === 'Escape') {
+                    close();
+                }
+            });
+            // mousedown (not click) so we beat input blur, which would close the list first.
+            list.addEventListener('mousedown', (e) => {
+                const li = e.target.closest('li[data-val]');
+                if (!li) return;
+                e.preventDefault();
+                commit(li.dataset.val);
+                input.focus();
+            });
+            toggle.addEventListener('mousedown', (e) => {
+                e.preventDefault();
+                if (list.hidden) { input.focus(); open(); } else close();
+            });
+            document.addEventListener('mousedown', (e) => {
+                if (!wrap.contains(e.target)) close();
+            });
         }
 
         async function loadManagers() {
@@ -515,6 +646,12 @@
 
         function updateSubmitButtonState() {
             const submitBtn = document.getElementById('submitButton');
+            // In post-submission mode the button is the reset CTA — leave it
+            // enabled regardless of form-field validity.
+            if (isPostSubmission) {
+                submitBtn.disabled = false;
+                return;
+            }
             const ledgerOk = !!document.getElementById('ledgerSelect').value;
             const managerOk = !!document.getElementById('managerSelect').value;
             const sourceCurrency = getCurrencyCode('sourceCurrencyInput');
@@ -631,6 +768,57 @@
             updateSubmitButtonState();
         }
 
+        // After a successful submission the button label flips to "Submit a
+        // New Report" and clicking it resets the form for the next entry.
+        // Keeps the user on the same page (which already verified their
+        // digital signature) without forcing a refresh.
+        function resetFormForNewReport() {
+            document.getElementById('sourceCurrencyInput').value = '';
+            document.getElementById('sourceAmountInput').value = '';
+            document.getElementById('targetCurrencyInput').value = '';
+            document.getElementById('targetAmountInput').value = '';
+            document.getElementById('descriptionInput').value = '';
+            document.getElementById('charCount').textContent = '0';
+            document.getElementById('conversionDateInput').value = todayYyyymmdd();
+
+            // Receipt attachment state
+            file = null;
+            fileName = '';
+            cachedConversionFileName = null;
+            document.getElementById('originalFileName').textContent = 'No file selected';
+            document.getElementById('contributionFileName').textContent = 'Waiting for file selection…';
+            document.getElementById('contributionLocation').textContent = 'Waiting for file selection…';
+            const preview = document.getElementById('uploaded-file-preview');
+            preview.style.display = 'none';
+            preview.src = '';
+
+            // Output area
+            const output = document.getElementById('outputMessage');
+            output.className = 'hidden';
+            output.innerHTML = '';
+
+            // Rate display
+            const rateEl = document.getElementById('rateDisplay');
+            if (rateEl) {
+                rateEl.textContent = 'Implied FX rate will appear here once both amounts are entered.';
+                rateEl.className = 'rate-display empty';
+            }
+
+            // Reset state + button label
+            isPostSubmission = false;
+            const submitBtn = document.getElementById('submitButton');
+            submitBtn.textContent = 'Submit Currency Conversion Report';
+            updateSubmitButtonState();
+        }
+
+        function handleSubmitButtonClick() {
+            if (isPostSubmission) {
+                resetFormForNewReport();
+            } else {
+                submitReport();
+            }
+        }
+
         async function submitReport() {
             const ledgerSelect = document.getElementById('ledgerSelect');
             const sourceCurrency = getCurrencyCode('sourceCurrencyInput');
@@ -719,6 +907,11 @@
                     output.innerHTML = `Currency conversion report sent to Edgar successfully.<br>View: <a id="telegramLink" href="https://truesight.me/submissions/raw-telegram-chatlogs" target="_blank">https://truesight.me/submissions/raw-telegram-chatlogs</a>`;
                     output.className = 'status';
                     isPostSubmission = true;
+                    // Flip the CTA into reset mode — click now clears the form
+                    // for a fresh entry instead of resubmitting the same data.
+                    submitBtn.textContent = 'Submit a New Report';
+                    submitBtn.disabled = false;
+                    return;
                 } else {
                     if (isMobileDevice() && navigator.share) {
                         const shareData = { text: shareText };
@@ -762,6 +955,11 @@
             statusElement.className = 'loading fade-in';
             await Promise.all([loadLedgers(), loadManagers(), loadCurrencies()]);
 
+            // Comboboxes wire up after the option list has loaded so the
+            // first focus already has results to show.
+            wireCurrencyCombobox('sourceCurrencyInput');
+            wireCurrencyCombobox('targetCurrencyInput');
+
             statusElement.textContent = '';
             statusElement.className = '';
             document.getElementById('info').style.display = 'block';
@@ -782,6 +980,23 @@
             });
             document.addEventListener('paste', (e) => {
                 if (e.clipboardData && e.clipboardData.files.length > 0) handleFile(e.clipboardData.files[0]);
+            });
+            // Pasting an image or file directly into the description textarea
+            // shouldn't dump binary into the text — intercept it and route to
+            // the receipt attachment slot instead. Plain-text pastes fall
+            // through to default behavior.
+            document.getElementById('descriptionInput').addEventListener('paste', (e) => {
+                if (e.clipboardData && e.clipboardData.files && e.clipboardData.files.length > 0) {
+                    e.preventDefault();
+                    handleFile(e.clipboardData.files[0]);
+                    // Flip the input-method back to upload so the user sees
+                    // the preview land in the receipt slot below.
+                    const sel = document.getElementById('inputMethod');
+                    if (sel.value !== 'upload') {
+                        sel.value = 'upload';
+                        sel.dispatchEvent(new Event('change', { bubbles: true }));
+                    }
+                }
             });
 
             ['sourceCurrencyInput', 'targetCurrencyInput'].forEach(id => {
@@ -807,7 +1022,7 @@
                 updateSubmitButtonState();
             });
             document.getElementById('managerSelect').addEventListener('change', updateSubmitButtonState);
-            document.getElementById('submitButton').addEventListener('click', submitReport);
+            document.getElementById('submitButton').addEventListener('click', handleSubmitButtonClick);
 
             toggleInputMethod();
         });

--- a/governor_contributor_admin.html
+++ b/governor_contributor_admin.html
@@ -15,7 +15,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260510"></script>
+  <script src="./menu.js?v=20260512a"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./scripts/permissions.js"></script>

--- a/governor_permissions.html
+++ b/governor_permissions.html
@@ -15,7 +15,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260510"></script>
+  <script src="./menu.js?v=20260512a"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./scripts/permissions.js"></script>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <meta property="og:type" content="website">
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
-  <script src="./menu.js?v=20260510"></script>
+  <script src="./menu.js?v=20260512a"></script>
   <script src="./tdg_balance.js"></script>
 
   <title>TrueSight DAO - Community Collaboration Tools</title>

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -1,0 +1,279 @@
+// DApp notification badge — Facebook-style red counter for action items
+// across DApp modules. Loaded by menu.js on every page so the operator
+// can spot pending work without loading each module.
+//
+// Architecture
+// ------------
+// Each module is a "source" registered via Notifications.register({...}).
+// A source's fetch() returns either null (no items / fetch failed — module
+// hidden from popup) or an object of the shape:
+//
+//   {
+//     count: <int>,                  // number contributed to the red badge
+//     label: <string>,               // module name shown in popup
+//     sublabel: <string>,            // short description e.g. "drafts to review"
+//     link: <string>,                // where clicking the entry sends the user
+//     items: [                       // optional, top N items shown nested in popup
+//       { title: <string>, link: <string>, since: <string> }
+//     ]
+//   }
+//
+// Sources fetch in parallel. The badge totals counts; null sources are
+// silently skipped. A source that throws is treated as null + logged.
+//
+// To add a new module: append a source via Notifications.register() in
+// this file (or from another script loaded after notifications.js). The
+// JSON contract above is the only thing the popup understands; new
+// modules don't need any change to this widget.
+
+(function (global) {
+  'use strict';
+
+  var STATE = {
+    sources: [],
+    results: {},          // id -> result (or null)
+    refreshing: false,
+    rendered: false,
+    open: false
+  };
+
+  var REFRESH_INTERVAL_MS = 5 * 60 * 1000;  // 5 minutes
+
+  // ----- Public API ---------------------------------------------------------
+
+  function register(source) {
+    if (!source || !source.id || typeof source.fetch !== 'function') {
+      console.warn('[notifications] register() expects {id, fetch}', source);
+      return;
+    }
+    STATE.sources.push(source);
+    // If the widget has already booted, refresh so the new source shows.
+    if (STATE.rendered) refresh();
+  }
+
+  function refresh() {
+    if (STATE.refreshing) return;
+    STATE.refreshing = true;
+    var pending = STATE.sources.map(function (src) {
+      return Promise.resolve()
+        .then(function () { return src.fetch(); })
+        .then(function (result) { STATE.results[src.id] = result || null; })
+        .catch(function (err) {
+          console.warn('[notifications] source "' + src.id + '" failed:', err);
+          STATE.results[src.id] = null;
+        });
+    });
+    return Promise.all(pending).finally(function () {
+      STATE.refreshing = false;
+      renderBadge();
+      renderPopup();
+    });
+  }
+
+  // ----- DOM ----------------------------------------------------------------
+
+  function ensureChrome() {
+    if (document.getElementById('tsd-notif-root')) return;
+    var root = document.createElement('div');
+    root.id = 'tsd-notif-root';
+    root.innerHTML = [
+      '<style>',
+      '  #tsd-notif-root { position: fixed; top: 0.75rem; right: 0.75rem; z-index: 9999; font-family: inherit; }',
+      '  #tsd-notif-btn { position: relative; width: 40px; height: 40px; border-radius: 50%; background: #fff; box-shadow: 0 1px 4px rgba(0,0,0,0.18); border: 1px solid #e1ddd4; cursor: pointer; display: flex; align-items: center; justify-content: center; padding: 0; }',
+      '  #tsd-notif-btn svg { width: 20px; height: 20px; fill: #4a4a4a; }',
+      '  #tsd-notif-btn:hover { background: #faf7f1; }',
+      '  #tsd-notif-badge { position: absolute; top: -4px; right: -4px; min-width: 18px; height: 18px; padding: 0 5px; border-radius: 9px; background: #d64545; color: #fff; font-size: 11px; font-weight: 700; line-height: 18px; text-align: center; box-sizing: border-box; display: none; }',
+      '  #tsd-notif-badge.has-count { display: inline-block; }',
+      '  #tsd-notif-popup { position: absolute; top: 48px; right: 0; min-width: 280px; max-width: 360px; background: #fff; border: 1px solid #e1ddd4; border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,0.16); padding: 0.5rem 0; display: none; }',
+      '  #tsd-notif-popup.open { display: block; }',
+      '  .tsd-notif-header { padding: 0.5rem 0.85rem; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em; color: #8a8275; border-bottom: 1px solid #f0ece4; }',
+      '  .tsd-notif-empty { padding: 0.85rem; color: #8a8275; font-size: 0.875rem; text-align: center; }',
+      '  .tsd-notif-entry { display: block; padding: 0.7rem 0.85rem; color: inherit; text-decoration: none; border-bottom: 1px solid #f6f3eb; }',
+      '  .tsd-notif-entry:last-child { border-bottom: none; }',
+      '  .tsd-notif-entry:hover { background: #faf7f1; }',
+      '  .tsd-notif-entry-title { font-weight: 600; font-size: 0.9375rem; color: #2a2a2a; display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; }',
+      '  .tsd-notif-entry-count { background: #d64545; color: #fff; min-width: 22px; height: 20px; padding: 0 6px; border-radius: 10px; font-size: 11px; font-weight: 700; line-height: 20px; text-align: center; box-sizing: border-box; }',
+      '  .tsd-notif-entry-sub { font-size: 0.8125rem; color: #6f6859; margin-top: 0.15rem; }',
+      '  .tsd-notif-items { margin: 0.4rem 0 0 0; padding: 0; list-style: none; font-size: 0.8125rem; color: #6f6859; }',
+      '  .tsd-notif-items li { padding: 0.15rem 0; }',
+      '</style>',
+      '<button id="tsd-notif-btn" type="button" aria-label="Notifications" aria-haspopup="true" aria-expanded="false">',
+      '  <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2a7 7 0 0 0-7 7v3.586l-1.707 1.707A1 1 0 0 0 4 16h16a1 1 0 0 0 .707-1.707L19 12.586V9a7 7 0 0 0-7-7zm0 20a3 3 0 0 0 3-3H9a3 3 0 0 0 3 3z"/></svg>',
+      '  <span id="tsd-notif-badge">0</span>',
+      '</button>',
+      '<div id="tsd-notif-popup" role="dialog" aria-label="Action items"></div>'
+    ].join('');
+    document.body.appendChild(root);
+
+    document.getElementById('tsd-notif-btn').addEventListener('click', function (e) {
+      e.stopPropagation();
+      togglePopup();
+    });
+    document.addEventListener('click', function (e) {
+      if (!STATE.open) return;
+      if (e.target.closest && e.target.closest('#tsd-notif-root')) return;
+      togglePopup(false);
+    });
+    STATE.rendered = true;
+  }
+
+  function togglePopup(force) {
+    var willOpen = (typeof force === 'boolean') ? force : !STATE.open;
+    STATE.open = willOpen;
+    var popup = document.getElementById('tsd-notif-popup');
+    var btn = document.getElementById('tsd-notif-btn');
+    if (!popup || !btn) return;
+    popup.classList.toggle('open', willOpen);
+    btn.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+    if (willOpen) renderPopup();
+  }
+
+  function renderBadge() {
+    var badge = document.getElementById('tsd-notif-badge');
+    if (!badge) return;
+    var total = 0;
+    Object.keys(STATE.results).forEach(function (id) {
+      var r = STATE.results[id];
+      if (r && typeof r.count === 'number') total += r.count;
+    });
+    badge.textContent = total > 99 ? '99+' : String(total);
+    badge.classList.toggle('has-count', total > 0);
+  }
+
+  function renderPopup() {
+    var popup = document.getElementById('tsd-notif-popup');
+    if (!popup) return;
+    var entries = STATE.sources
+      .map(function (src) { return STATE.results[src.id]; })
+      .filter(function (r) { return r && typeof r.count === 'number' && r.count > 0; });
+
+    var html = ['<div class="tsd-notif-header">Action items</div>'];
+    if (entries.length === 0) {
+      html.push('<div class="tsd-notif-empty">No pending action items.</div>');
+    } else {
+      entries.forEach(function (r) {
+        var itemsHtml = '';
+        if (Array.isArray(r.items) && r.items.length) {
+          itemsHtml = '<ul class="tsd-notif-items">' +
+            r.items.slice(0, 4).map(function (it) {
+              return '<li>' + escapeHtml(it.title || '') +
+                (it.since ? ' · <em>' + escapeHtml(it.since) + '</em>' : '') +
+                '</li>';
+            }).join('') +
+            '</ul>';
+        }
+        html.push(
+          '<a class="tsd-notif-entry" href="' + escapeAttr(r.link || '#') + '">' +
+            '<div class="tsd-notif-entry-title"><span>' + escapeHtml(r.label || '') + '</span>' +
+              '<span class="tsd-notif-entry-count">' + r.count + '</span>' +
+            '</div>' +
+            (r.sublabel ? '<div class="tsd-notif-entry-sub">' + escapeHtml(r.sublabel) + '</div>' : '') +
+            itemsHtml +
+          '</a>'
+        );
+      });
+    }
+    popup.innerHTML = html.join('');
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+  }
+  function escapeAttr(s) { return escapeHtml(s); }
+
+  // ----- Built-in sources ---------------------------------------------------
+
+  // Outbound Review (warmup, follow-up, prospect-replied drafts)
+  // Uses the same GAS endpoint warmup_review.html already calls — no new
+  // server-side work needed.
+  register({
+    id: 'warmup',
+    fetch: function () {
+      var routes = global.Routes;
+      if (!routes || !routes.gas || !routes.gas.storesHitList) return null;
+      var url = routes.gas.storesHitList + '?action=getWarmupReviewQueue';
+      return fetch(url, { method: 'GET' })
+        .then(function (r) { return r.ok ? r.json() : null; })
+        .then(function (json) {
+          if (!json || json.status !== 'success' || !json.data) return null;
+          var counts = json.data.counts || {};
+          var warmup = Number(counts['AI/Warm-up'] || 0);
+          var followup = Number(counts['AI/Follow-up'] || 0);
+          var replied = Number(counts['AI/Prospect Replied'] || 0);
+          var total = warmup + followup + replied;
+          if (!total) return null;
+          var parts = [];
+          if (replied) parts.push(replied + ' prospect replied');
+          if (followup) parts.push(followup + ' follow-up');
+          if (warmup) parts.push(warmup + ' warm-up');
+          return {
+            count: total,
+            label: 'Outbound Review',
+            sublabel: parts.join(' · ') + ' (drafts to review)',
+            link: './warmup_review.html'
+          };
+        });
+    }
+  });
+
+  // Partner Check-in follow-ups due
+  // TODO: requires a new GAS action on tdg_shipping_planner.
+  // Proposed shape:
+  //   GET .../exec?action=get_partner_followups_due
+  //   → { status: 'success', data: { count: N, partners: [{name, last_check_in, since_days}] } }
+  // Cadence rule (initial proposal, refine after first week of data):
+  //   Partner-status store with no check-in in the last 30 days = due.
+  // Once the GAS action ships, replace the body below with a real fetch.
+  // Until then this source returns null and is silently hidden.
+  register({
+    id: 'partner_followups',
+    fetch: function () {
+      var routes = global.Routes;
+      if (!routes || !routes.gas || !routes.gas.shipping) return null;
+      var url = routes.gas.shipping + '?action=get_partner_followups_due';
+      return fetch(url, { method: 'GET' })
+        .then(function (r) { return r.ok ? r.json() : null; })
+        .then(function (json) {
+          if (!json || json.status !== 'success' || !json.data) return null;
+          var data = json.data;
+          var count = Number(data.count || (data.partners ? data.partners.length : 0));
+          if (!count) return null;
+          var items = (data.partners || []).slice(0, 4).map(function (p) {
+            return {
+              title: p.name || p.partner || 'Partner',
+              since: (p.since_days != null) ? (p.since_days + 'd') : ''
+            };
+          });
+          return {
+            count: count,
+            label: 'Partner Check-in',
+            sublabel: count + ' follow-up' + (count === 1 ? '' : 's') + ' due',
+            link: './partner_check_in.html',
+            items: items
+          };
+        })
+        .catch(function () { return null; });  // GAS action may not exist yet
+    }
+  });
+
+  // ----- Boot ---------------------------------------------------------------
+
+  function boot() {
+    ensureChrome();
+    refresh();
+    setInterval(refresh, REFRESH_INTERVAL_MS);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot);
+  } else {
+    boot();
+  }
+
+  global.Notifications = {
+    register: register,
+    refresh: refresh
+  };
+})(typeof window !== 'undefined' ? window : this);

--- a/menu.js
+++ b/menu.js
@@ -85,4 +85,17 @@
     });
     container.appendChild(select);
   });
+
+  // Inject the notifications widget (red-badge action-item indicator)
+  // on every page that loads menu.js. Loaded async so it never blocks
+  // the menu render. The widget self-mounts a fixed-position badge in
+  // the top-right corner; see js/notifications.js for the source contract.
+  document.addEventListener('DOMContentLoaded', function () {
+    if (document.getElementById('tsd-notif-script')) return;
+    var s = document.createElement('script');
+    s.id = 'tsd-notif-script';
+    s.src = './js/notifications.js?v=20260512a';
+    s.async = true;
+    document.head.appendChild(s);
+  });
 })();

--- a/notarize.html
+++ b/notarize.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260510"></script>
+  <script src="./menu.js?v=20260512a"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/partner_check_in.html
+++ b/partner_check_in.html
@@ -20,7 +20,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         body {

--- a/register_farm.html
+++ b/register_farm.html
@@ -17,7 +17,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260510"></script>
+  <script src="./menu.js?v=20260512a"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/repackaging_planner.html
+++ b/repackaging_planner.html
@@ -11,7 +11,7 @@
   <meta property="og:type" content="website">
   <link rel="icon" type="image/png" href="https://raw.githubusercontent.com/TrueSightDAO/.github/main/assets/20240612_truesight_dao_logo_square.png">
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260510"></script>
+  <script src="./menu.js?v=20260512a"></script>
   <script src="./tdg_balance.js"></script>
   <title>Repackaging Planner - TrueSight DAO</title>
   <style>

--- a/report_asset_receipt.html
+++ b/report_asset_receipt.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/report_capital_injection.html
+++ b/report_capital_injection.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/report_contribution.html
+++ b/report_contribution.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
 

--- a/report_dao_expenses.html
+++ b/report_dao_expenses.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     <script src="./expense-form-utils.js"></script>

--- a/report_inventory_movement.html
+++ b/report_inventory_movement.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     <script src="./scripts/permissions.js"></script>

--- a/report_sales.html
+++ b/report_sales.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     

--- a/report_tree_planting.html
+++ b/report_tree_planting.html
@@ -17,7 +17,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260510"></script>
+  <script src="./menu.js?v=20260512a"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/restock_recommender.html
+++ b/restock_recommender.html
@@ -24,7 +24,7 @@
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         body {

--- a/review_proposal.html
+++ b/review_proposal.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         * {

--- a/scanner.html
+++ b/scanner.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
     
     <style>

--- a/service-worker.js
+++ b/service-worker.js
@@ -44,11 +44,12 @@ const URLS_TO_CACHE = [
   './governor_contributor_admin.html',
   './governor_permissions.html',
   // Scripts
-  './menu.js?v=20260512',
+  './menu.js?v=20260512a',
   './routes.js',
   './service-worker.js',
   './js/treasury_cache.js',
   './js/dapp_footer_links.js?v=1',
+  './js/notifications.js?v=20260512a',
   './scripts/dao_members_cache.js',
   './scripts/permissions.js',
   // External libraries

--- a/shipping_planner.html
+++ b/shipping_planner.html
@@ -53,7 +53,7 @@
     </script>
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCS5tz9sp9mWG6d_glVO19UUk8ZyZ3LdbQ&callback=onGoogleMapsReady&v=weekly&loading=async&libraries=places"></script>
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./js/treasury_cache.js"></script>
     

--- a/store_interaction_history.html
+++ b/store_interaction_history.html
@@ -20,7 +20,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/stores_by_status.html
+++ b/stores_by_status.html
@@ -15,7 +15,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/stores_nearby.html
+++ b/stores_nearby.html
@@ -45,7 +45,7 @@
     </script>
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBWmnvjWeYIEju0JLbfN-Z09k1HEsXzWe4&callback=onGoogleMapsReady&v=weekly&loading=async&libraries=places"></script>
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
     
     <!-- Leaflet.js for maps (no API key required) -->

--- a/submit_feedback.html
+++ b/submit_feedback.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/update_qr_code.html
+++ b/update_qr_code.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/edgar_payload_helper.js"></script>
 

--- a/verify_request.html
+++ b/verify_request.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260510"></script>
+  <script src="./menu.js?v=20260512a"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/view_inventory_holdings.html
+++ b/view_inventory_holdings.html
@@ -14,7 +14,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./js/treasury_cache.js"></script>
 

--- a/view_open_proposals.html
+++ b/view_open_proposals.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260510"></script>
+    <script src="./menu.js?v=20260512a"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/warmup_review.html
+++ b/warmup_review.html
@@ -15,7 +15,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260510"></script>
+  <script src="./menu.js?v=20260512a"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./scripts/permissions.js"></script>

--- a/withdraw_voting_rights.html
+++ b/withdraw_voting_rights.html
@@ -15,7 +15,7 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260510"></script>
+  <script src="./menu.js?v=20260512a"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {


### PR DESCRIPTION
## Summary

Adds a shared red-badge notification widget to every DApp page so the operator can spot pending action items without opening each module. Triggered by Gary's question this morning about wanting a Facebook-style indicator for things like the warmup-queue drafts awaiting review and upcoming Partner Check-in follow-ups.

## How it works

- **`js/notifications.js`** (new) — fixed-position bell icon top-right + red counter badge + click-to-open popup. Self-mounts on every page that loads `menu.js`. Refreshes every 5 minutes.
- **`menu.js`** — async-injects `js/notifications.js` after rendering the nav menu. One file change covers all 33 DApp pages.
- **Module contract** — each module is a `source` registered via `Notifications.register({id, fetch})`. `fetch()` returns `null` (hidden) or `{count, label, sublabel, link, items}`. Sources fire in parallel; failures are silently skipped.

## Modules wired in v1

1. **Outbound Review** — sums the three warmup-review cohorts (AI/Warm-up, AI/Follow-up, AI/Prospect Replied) from the existing `getWarmupReviewQueue` endpoint. **Zero new GAS code needed**; uses the same call `warmup_review.html` already makes.

2. **Partner Check-in follow-ups due** — registered with a placeholder fetch against a proposed new GAS action `get_partner_followups_due` on `tdg_shipping_planner`. Until that action is deployed, the source returns null and is silently hidden from the badge. The cadence rule (proposed: 'no check-in in the last 30 days for a Partner-status store') can be tuned at the GAS layer without touching the widget.

## Anti-pattern guarded against

The warmup queue currently has ~67 stores. Most are gated behind the 'wait till settle' cadence rule and aren't ready to send (the *Where 道 Integrates with DAO* post explained the rationale). The notification source still counts them because the warmup_review.html cohort labels are themselves the gate output. If this over-pressures the badge in practice, the next iteration adds a 'send-ready' filter at the GAS layer rather than client-side.

## Cache busting

- `menu.js` bumped to `?v=20260512a` across all 33 pages (32 were on `20260510`, 1 on `20260512`)
- `js/notifications.js` added to `service-worker.js` URLS_TO_CACHE

## v1.1 follow-up (separate PR, requires GAS clasp-push)

- Add `get_partner_followups_due` action to `tdg_shipping_planner` Apps Script
- Optional: add `?send_ready=true` filter to `getWarmupReviewQueue` so the badge can show only drafts that have passed the cadence gate

## Test plan

- [x] Local smoke: all DApp pages serve 200; menu.js bottom shows injection block; warmup_review.html refs new version
- [ ] **Operator review:** open `partner_check_in.html` and `warmup_review.html`, confirm bell appears top-right and badge shows a count if the warmup queue has drafts
- [ ] Click the bell, confirm popup opens with 'Outbound Review · N (drafts to review)' entry that deep-links into `warmup_review.html`
- [ ] Click outside the popup, confirm it closes
- [ ] No console errors on pages that load it
- [ ] Verify the Partner Check-in row is hidden in the popup (until the GAS action exists)