### PR TITLE
DApp notifications: wire Partner Check-in follow-ups (v1 module 2)

### DIFF
--- a/batch_qr_generator.html
+++ b/batch_qr_generator.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
     
     <style>

--- a/chat.html
+++ b/chat.html
@@ -22,7 +22,7 @@
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/edgar_payload_helper.js"></script>

--- a/create_proposal.html
+++ b/create_proposal.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         * {

--- a/create_signature.html
+++ b/create_signature.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
   
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512a"></script>
+  <script src="./menu.js?v=20260512b"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/edgar_payload_helper.js"></script>

--- a/currency_conversion.html
+++ b/currency_conversion.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./js/treasury_cache.js"></script>
 

--- a/governor_contributor_admin.html
+++ b/governor_contributor_admin.html
@@ -15,7 +15,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512a"></script>
+  <script src="./menu.js?v=20260512b"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./scripts/permissions.js"></script>

--- a/governor_permissions.html
+++ b/governor_permissions.html
@@ -15,7 +15,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512a"></script>
+  <script src="./menu.js?v=20260512b"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./scripts/permissions.js"></script>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <meta property="og:type" content="website">
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
-  <script src="./menu.js?v=20260512a"></script>
+  <script src="./menu.js?v=20260512b"></script>
   <script src="./tdg_balance.js"></script>
 
   <title>TrueSight DAO - Community Collaboration Tools</title>

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -219,42 +219,87 @@
   });
 
   // Partner Check-in follow-ups due
-  // TODO: requires a new GAS action on tdg_shipping_planner.
-  // Proposed shape:
-  //   GET .../exec?action=get_partner_followups_due
-  //   → { status: 'success', data: { count: N, partners: [{name, last_check_in, since_days}] } }
-  // Cadence rule (initial proposal, refine after first week of data):
-  //   Partner-status store with no check-in in the last 30 days = due.
-  // Once the GAS action ships, replace the body below with a real fetch.
-  // Until then this source returns null and is silently hidden.
+  // Uses the existing `list_partners_needing_attention` action on
+  // tdg_shipping_planner, which returns partners whose operator-specified
+  // Next Check-in Date is overdue or within 3 days (today + 3 cutoff). The
+  // cadence is operator-driven — Gary picks the next-check-in date when
+  // filing each check-in, so the badge surfaces exactly what the operator
+  // asked to be reminded about (avoids the "tracker tells you to act"
+  // anti-pattern documented in
+  // feedback_check_tracking_before_recommending_action.md).
+  //
+  // The GAS response carries partner_id (slug). We join against
+  // partners-velocity.json to surface partner_name in the popup.
+  var partnersVelocityCache = null;
+  function getPartnerNameMap() {
+    if (partnersVelocityCache) return Promise.resolve(partnersVelocityCache);
+    var url = 'https://raw.githubusercontent.com/TrueSightDAO/agroverse-inventory/main/partners-velocity.json';
+    return fetch(url, { method: 'GET', cache: 'no-cache' })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (json) {
+        var map = {};
+        if (json && json.partners && typeof json.partners === 'object') {
+          Object.keys(json.partners).forEach(function (slug) {
+            var p = json.partners[slug];
+            if (p && p.partner_name) map[slug] = p.partner_name;
+          });
+        }
+        partnersVelocityCache = map;
+        return map;
+      })
+      .catch(function () { return {}; });
+  }
+
   register({
     id: 'partner_followups',
     fetch: function () {
       var routes = global.Routes;
       if (!routes || !routes.gas || !routes.gas.shipping) return null;
-      var url = routes.gas.shipping + '?action=get_partner_followups_due';
-      return fetch(url, { method: 'GET' })
+      var url = routes.gas.shipping + '?action=list_partners_needing_attention';
+      var apiPromise = fetch(url, { method: 'GET' })
         .then(function (r) { return r.ok ? r.json() : null; })
-        .then(function (json) {
+        .catch(function () { return null; });
+      return Promise.all([apiPromise, getPartnerNameMap()])
+        .then(function (parts) {
+          var json = parts[0];
+          var nameMap = parts[1] || {};
           if (!json || json.status !== 'success' || !json.data) return null;
-          var data = json.data;
-          var count = Number(data.count || (data.partners ? data.partners.length : 0));
-          if (!count) return null;
-          var items = (data.partners || []).slice(0, 4).map(function (p) {
-            return {
-              title: p.name || p.partner || 'Partner',
-              since: (p.since_days != null) ? (p.since_days + 'd') : ''
-            };
+          var partners = json.data.partners || [];
+          if (!partners.length) return null;
+
+          // Sort: overdue first (largest days_overdue first), then upcoming
+          partners.sort(function (a, b) {
+            return (b.days_overdue || 0) - (a.days_overdue || 0);
           });
+
+          var items = partners.slice(0, 4).map(function (p) {
+            var pid = String(p.partner_id || '');
+            var name = nameMap[pid] || pid || 'Partner';
+            var days = Number(p.days_overdue);
+            var since;
+            if (isNaN(days)) since = '';
+            else if (days > 0) since = days + 'd overdue';
+            else if (days === 0) since = 'due today';
+            else since = 'due in ' + (-days) + 'd';
+            return { title: name, since: since };
+          });
+
+          var overdueCount = partners.filter(function (p) {
+            return Number(p.days_overdue) > 0;
+          }).length;
+          var sublabel = overdueCount
+            ? overdueCount + ' overdue · ' + (partners.length - overdueCount) + ' upcoming'
+            : partners.length + ' upcoming check-in' + (partners.length === 1 ? '' : 's');
+
           return {
-            count: count,
+            count: partners.length,
             label: 'Partner Check-in',
-            sublabel: count + ' follow-up' + (count === 1 ? '' : 's') + ' due',
+            sublabel: sublabel,
             link: './partner_check_in.html',
             items: items
           };
         })
-        .catch(function () { return null; });  // GAS action may not exist yet
+        .catch(function () { return null; });
     }
   });
 

--- a/menu.js
+++ b/menu.js
@@ -94,7 +94,7 @@
     if (document.getElementById('tsd-notif-script')) return;
     var s = document.createElement('script');
     s.id = 'tsd-notif-script';
-    s.src = './js/notifications.js?v=20260512a';
+    s.src = './js/notifications.js?v=20260512b';
     s.async = true;
     document.head.appendChild(s);
   });

--- a/notarize.html
+++ b/notarize.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512a"></script>
+  <script src="./menu.js?v=20260512b"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/partner_check_in.html
+++ b/partner_check_in.html
@@ -20,7 +20,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         body {

--- a/register_farm.html
+++ b/register_farm.html
@@ -17,7 +17,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512a"></script>
+  <script src="./menu.js?v=20260512b"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/repackaging_planner.html
+++ b/repackaging_planner.html
@@ -11,7 +11,7 @@
   <meta property="og:type" content="website">
   <link rel="icon" type="image/png" href="https://raw.githubusercontent.com/TrueSightDAO/.github/main/assets/20240612_truesight_dao_logo_square.png">
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512a"></script>
+  <script src="./menu.js?v=20260512b"></script>
   <script src="./tdg_balance.js"></script>
   <title>Repackaging Planner - TrueSight DAO</title>
   <style>

--- a/report_asset_receipt.html
+++ b/report_asset_receipt.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/report_capital_injection.html
+++ b/report_capital_injection.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/report_contribution.html
+++ b/report_contribution.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
 

--- a/report_dao_expenses.html
+++ b/report_dao_expenses.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     <script src="./expense-form-utils.js"></script>

--- a/report_inventory_movement.html
+++ b/report_inventory_movement.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     <script src="./scripts/permissions.js"></script>

--- a/report_sales.html
+++ b/report_sales.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     

--- a/report_tree_planting.html
+++ b/report_tree_planting.html
@@ -17,7 +17,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512a"></script>
+  <script src="./menu.js?v=20260512b"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/restock_recommender.html
+++ b/restock_recommender.html
@@ -24,7 +24,7 @@
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         body {

--- a/review_proposal.html
+++ b/review_proposal.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         * {

--- a/scanner.html
+++ b/scanner.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
     
     <style>

--- a/service-worker.js
+++ b/service-worker.js
@@ -44,12 +44,12 @@ const URLS_TO_CACHE = [
   './governor_contributor_admin.html',
   './governor_permissions.html',
   // Scripts
-  './menu.js?v=20260512a',
+  './menu.js?v=20260512b',
   './routes.js',
   './service-worker.js',
   './js/treasury_cache.js',
   './js/dapp_footer_links.js?v=1',
-  './js/notifications.js?v=20260512a',
+  './js/notifications.js?v=20260512b',
   './scripts/dao_members_cache.js',
   './scripts/permissions.js',
   // External libraries

--- a/shipping_planner.html
+++ b/shipping_planner.html
@@ -53,7 +53,7 @@
     </script>
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCS5tz9sp9mWG6d_glVO19UUk8ZyZ3LdbQ&callback=onGoogleMapsReady&v=weekly&loading=async&libraries=places"></script>
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./js/treasury_cache.js"></script>
     

--- a/store_interaction_history.html
+++ b/store_interaction_history.html
@@ -20,7 +20,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/stores_by_status.html
+++ b/stores_by_status.html
@@ -15,7 +15,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/stores_nearby.html
+++ b/stores_nearby.html
@@ -45,7 +45,7 @@
     </script>
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBWmnvjWeYIEju0JLbfN-Z09k1HEsXzWe4&callback=onGoogleMapsReady&v=weekly&loading=async&libraries=places"></script>
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
     
     <!-- Leaflet.js for maps (no API key required) -->

--- a/submit_feedback.html
+++ b/submit_feedback.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/update_qr_code.html
+++ b/update_qr_code.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/edgar_payload_helper.js"></script>
 

--- a/verify_request.html
+++ b/verify_request.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512a"></script>
+  <script src="./menu.js?v=20260512b"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/view_inventory_holdings.html
+++ b/view_inventory_holdings.html
@@ -14,7 +14,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./js/treasury_cache.js"></script>
 

--- a/view_open_proposals.html
+++ b/view_open_proposals.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512a"></script>
+    <script src="./menu.js?v=20260512b"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/warmup_review.html
+++ b/warmup_review.html
@@ -15,7 +15,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512a"></script>
+  <script src="./menu.js?v=20260512b"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./scripts/permissions.js"></script>

--- a/withdraw_voting_rights.html
+++ b/withdraw_voting_rights.html
@@ -15,7 +15,7 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512a"></script>
+  <script src="./menu.js?v=20260512b"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {


### PR DESCRIPTION
## Summary

Wires the Partner Check-in follow-ups notification source against the existing live GAS endpoint. With this PR, v1 of the notification badge has both modules fully wired.

## What changed

Turns out `list_partners_needing_attention` is **already live** on `tdg_shipping_planner` — `getDocumentByName(MAIN_LEDGER).getSheetByName('Partner Check-ins')` joined by operator-specified `Next Check-in Date`, with a today+3 cutoff. Zero new GAS code needed; just point `notifications.js` at the right action.

- Swap placeholder `get_partner_followups_due` → live `list_partners_needing_attention`
- Join GAS response (partner_id slugs) against `partners-velocity.json` for human-readable names in the popup; cache the velocity fetch per page load
- Differentiate badge labels: `Nd overdue` / `due today` / `due in Nd`
- Sort items in popup most-overdue first
- Sublabel shows the overdue/upcoming split when both are present

## Why this design wins on the anti-pattern front

The cadence is **operator-driven**, not metric-driven. Gary picks the Next Check-in Date when filing each check-in. The badge surfaces exactly what he asked to be reminded about — never a generic '30 days since last check-in' nag. This is the right shape per `feedback_check_tracking_before_recommending_action.md`: the tracker holds the operator's intent, and the badge respects it.

## Live verification

`curl -sL '<shipping_planner_exec>?action=list_partners_needing_attention'` → `{status:'success', data:{partners:[]}}` (empty because no check-ins with upcoming/overdue Next-Check-in dates have been filed yet — the surface only shipped May 12). The source returns null in that case and is silently hidden from the badge until Gary's first check-in matures.

## Cache busting

- `menu.js` bumped to `?v=20260512b` across all 33 pages
- `js/notifications.js` referenced as `?v=20260512b` in menu.js injection + service-worker URLS_TO_CACHE

## Test plan
- [x] GAS endpoint returns `{status:'success', data:{partners:[]}}` (currently empty — by design)
- [x] All paths serve 200 locally
- [ ] **Operator:** file a test partner check-in with Next Check-in Date = today or earlier, hard-refresh any DApp page, confirm the bell badge shows '1' and the popup lists 'Partner Check-in · 1 overdue' with the partner_name from velocity
- [ ] Set Next Check-in Date to today+5, refresh, confirm the partner is NOT in the popup (beyond 3-day lookahead)
- [ ] Set Next Check-in Date to today+2, refresh, confirm the partner shows as 'due in 2d'