### PR TITLE
DApp notifications: wire Partner Stock attention (v1.1 module 3)

### DIFF
--- a/batch_qr_generator.html
+++ b/batch_qr_generator.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
     
     <style>

--- a/chat.html
+++ b/chat.html
@@ -22,7 +22,7 @@
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/edgar_payload_helper.js"></script>

--- a/create_proposal.html
+++ b/create_proposal.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         * {

--- a/create_signature.html
+++ b/create_signature.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
   
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512b"></script>
+  <script src="./menu.js?v=20260512c"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/edgar_payload_helper.js"></script>

--- a/currency_conversion.html
+++ b/currency_conversion.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./js/treasury_cache.js"></script>
 

--- a/governor_contributor_admin.html
+++ b/governor_contributor_admin.html
@@ -15,7 +15,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512b"></script>
+  <script src="./menu.js?v=20260512c"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./scripts/permissions.js"></script>

--- a/governor_permissions.html
+++ b/governor_permissions.html
@@ -15,7 +15,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512b"></script>
+  <script src="./menu.js?v=20260512c"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./scripts/permissions.js"></script>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <meta property="og:type" content="website">
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
-  <script src="./menu.js?v=20260512b"></script>
+  <script src="./menu.js?v=20260512c"></script>
   <script src="./tdg_balance.js"></script>
 
   <title>TrueSight DAO - Community Collaboration Tools</title>

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -230,24 +230,66 @@
   //
   // The GAS response carries partner_id (slug). We join against
   // partners-velocity.json to surface partner_name in the popup.
-  var partnersVelocityCache = null;
-  function getPartnerNameMap() {
-    if (partnersVelocityCache) return Promise.resolve(partnersVelocityCache);
-    var url = 'https://raw.githubusercontent.com/TrueSightDAO/agroverse-inventory/main/partners-velocity.json';
-    return fetch(url, { method: 'GET', cache: 'no-cache' })
+  // The same velocity blob also feeds the Partner Stock source below,
+  // so we cache the entire JSON, not just a name map.
+  var velocityCache = null;
+  var inventoryCache = null;
+  var VELOCITY_URL  = 'https://raw.githubusercontent.com/TrueSightDAO/agroverse-inventory/main/partners-velocity.json';
+  var INVENTORY_URL = 'https://raw.githubusercontent.com/TrueSightDAO/agroverse-inventory/main/partners-inventory.json';
+
+  function fetchVelocityJson() {
+    if (velocityCache) return Promise.resolve(velocityCache);
+    return fetch(VELOCITY_URL, { method: 'GET', cache: 'no-cache' })
       .then(function (r) { return r.ok ? r.json() : null; })
-      .then(function (json) {
-        var map = {};
-        if (json && json.partners && typeof json.partners === 'object') {
-          Object.keys(json.partners).forEach(function (slug) {
-            var p = json.partners[slug];
-            if (p && p.partner_name) map[slug] = p.partner_name;
-          });
-        }
-        partnersVelocityCache = map;
-        return map;
-      })
-      .catch(function () { return {}; });
+      .then(function (json) { velocityCache = json; return json; })
+      .catch(function () { return null; });
+  }
+  function fetchInventoryJson() {
+    if (inventoryCache) return Promise.resolve(inventoryCache);
+    return fetch(INVENTORY_URL, { method: 'GET', cache: 'no-cache' })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (json) { inventoryCache = json; return json; })
+      .catch(function () { return null; });
+  }
+  function getPartnerNameMap() {
+    return fetchVelocityJson().then(function (json) {
+      var map = {};
+      if (json && json.partners && typeof json.partners === 'object') {
+        Object.keys(json.partners).forEach(function (slug) {
+          var p = json.partners[slug];
+          if (p && p.partner_name) map[slug] = p.partner_name;
+        });
+      }
+      return map;
+    });
+  }
+
+  // Date helpers (lifted verbatim from partner_check_in.html so the
+  // bell's stock-attention scoring matches what the page itself shows).
+  function daysSince(isoDate) {
+    if (!isoDate) return null;
+    var d = new Date(isoDate + 'T00:00:00Z');
+    if (isNaN(d.getTime())) return null;
+    return Math.floor((Date.now() - d.getTime()) / 86400000);
+  }
+  function relativeAge(isoDate) {
+    var days = daysSince(isoDate);
+    if (days === null) return 'unknown';
+    if (days < 0) return 'in the future';
+    if (days === 0) return 'today';
+    if (days === 1) return 'yesterday';
+    if (days < 14) return days + ' days ago';
+    if (days < 60) return Math.round(days / 7) + ' weeks ago';
+    if (days < 365) return Math.round(days / 30) + ' months ago';
+    return Math.round(days / 365 * 10) / 10 + ' years ago';
+  }
+  function slugDisplayName(slug) {
+    var s = String(slug || '').split('/').pop();
+    return s.split('-').map(function (w) {
+      if (!w) return '';
+      if (w.length <= 2) return w.toUpperCase();
+      return w.charAt(0).toUpperCase() + w.slice(1);
+    }).join(' ').trim();
   }
 
   register({
@@ -297,6 +339,111 @@
             sublabel: sublabel,
             link: './partner_check_in.html',
             items: items
+          };
+        })
+        .catch(function () { return null; });
+    }
+  });
+
+  // Partner Stock attention
+  // Mirrors the "Needs Attention" scoring on partner_check_in.html so the
+  // bell surfaces the same business-signal urgency the page does. Reads two
+  // static GitHub-hosted JSONs (partners-velocity.json + partners-inventory.json),
+  // both cached for the lifetime of the page.
+  //
+  // Severity rules (lifted verbatim from partner_check_in.html computeAttentionList):
+  //   - critical: totalInv === 0          (out of stock)
+  //   - warning : totalInv <= 3           (running low — N left)
+  //   - info    : any SKU last_sale > 45d (dormant)
+  //
+  // Distinct from the partner_followups source above: this source surfaces
+  // partners the business signals are flagging RIGHT NOW (data-driven),
+  // not partners on the operator's planned check-in calendar (operator-driven).
+  // Both can fire simultaneously on the same partner — that's by design;
+  // they represent independent reasons to look at the partner.
+  register({
+    id: 'partner_stock',
+    fetch: function () {
+      return Promise.all([fetchVelocityJson(), fetchInventoryJson()])
+        .then(function (parts) {
+          var velocity = parts[0];
+          var inventory = parts[1];
+          if (!velocity || !velocity.partners) return null;
+
+          var RETAIL_TYPES = { 'Consignment': true, 'Wholesale': true };
+          var attention = [];
+
+          Object.keys(velocity.partners).forEach(function (slug) {
+            if (slug.indexOf('/') !== -1) return;  // skip cooperative slugs
+            var vel = velocity.partners[slug];
+            var ptype = (vel && vel.partner_type) || 'Consignment';
+            if (RETAIL_TYPES[ptype] !== true) return;
+
+            var inv = inventory && inventory.partners && inventory.partners[slug];
+            var totalInv = 0;
+            var reasons = [];
+            var severity = null;
+
+            if (inv && inv.items) {
+              inv.items.forEach(function (it) { totalInv += (it.venueInventory || 0); });
+              if (totalInv === 0) {
+                reasons.push('out of stock');
+                severity = 'critical';
+              } else if (totalInv <= 3) {
+                reasons.push('running low (' + totalInv + ' left)');
+                severity = 'warning';
+              }
+            }
+
+            if (vel && vel.items) {
+              Object.keys(vel.items).forEach(function (sku) {
+                var it = vel.items[sku];
+                if (it.last_sale_date) {
+                  var ds = daysSince(it.last_sale_date);
+                  if (ds !== null && ds > 45) {
+                    reasons.push('last sale ' + relativeAge(it.last_sale_date));
+                    if (!severity) severity = 'info';
+                  }
+                }
+              });
+            }
+
+            if (!reasons.length) return;
+            attention.push({
+              slug: slug,
+              name: (vel && vel.partner_name) || slugDisplayName(slug),
+              severity: severity,
+              reasons: reasons
+            });
+          });
+
+          if (!attention.length) return null;
+
+          // Sort: critical → warning → info, then alphabetical
+          var sevOrder = { critical: 0, warning: 1, info: 2 };
+          attention.sort(function (a, b) {
+            if (sevOrder[a.severity] !== sevOrder[b.severity]) {
+              return sevOrder[a.severity] - sevOrder[b.severity];
+            }
+            return a.name.localeCompare(b.name);
+          });
+
+          var critical = attention.filter(function (a) { return a.severity === 'critical'; }).length;
+          var warning  = attention.filter(function (a) { return a.severity === 'warning';  }).length;
+          var dormant  = attention.filter(function (a) { return a.severity === 'info';     }).length;
+          var subParts = [];
+          if (critical) subParts.push(critical + ' out of stock');
+          if (warning)  subParts.push(warning  + ' low stock');
+          if (dormant)  subParts.push(dormant  + ' dormant');
+
+          return {
+            count: attention.length,
+            label: 'Partner Stock',
+            sublabel: subParts.join(' · '),
+            link: './partner_check_in.html',
+            items: attention.slice(0, 4).map(function (a) {
+              return { title: a.name, since: a.reasons[0] };
+            })
           };
         })
         .catch(function () { return null; });

--- a/menu.js
+++ b/menu.js
@@ -94,7 +94,7 @@
     if (document.getElementById('tsd-notif-script')) return;
     var s = document.createElement('script');
     s.id = 'tsd-notif-script';
-    s.src = './js/notifications.js?v=20260512b';
+    s.src = './js/notifications.js?v=20260512c';
     s.async = true;
     document.head.appendChild(s);
   });

--- a/notarize.html
+++ b/notarize.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512b"></script>
+  <script src="./menu.js?v=20260512c"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/partner_check_in.html
+++ b/partner_check_in.html
@@ -20,7 +20,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         body {

--- a/register_farm.html
+++ b/register_farm.html
@@ -17,7 +17,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512b"></script>
+  <script src="./menu.js?v=20260512c"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/repackaging_planner.html
+++ b/repackaging_planner.html
@@ -11,7 +11,7 @@
   <meta property="og:type" content="website">
   <link rel="icon" type="image/png" href="https://raw.githubusercontent.com/TrueSightDAO/.github/main/assets/20240612_truesight_dao_logo_square.png">
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512b"></script>
+  <script src="./menu.js?v=20260512c"></script>
   <script src="./tdg_balance.js"></script>
   <title>Repackaging Planner - TrueSight DAO</title>
   <style>

--- a/report_asset_receipt.html
+++ b/report_asset_receipt.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/report_capital_injection.html
+++ b/report_capital_injection.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/report_contribution.html
+++ b/report_contribution.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
 

--- a/report_dao_expenses.html
+++ b/report_dao_expenses.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     <script src="./expense-form-utils.js"></script>

--- a/report_inventory_movement.html
+++ b/report_inventory_movement.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     <script src="./scripts/permissions.js"></script>

--- a/report_sales.html
+++ b/report_sales.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     

--- a/report_tree_planting.html
+++ b/report_tree_planting.html
@@ -17,7 +17,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512b"></script>
+  <script src="./menu.js?v=20260512c"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/restock_recommender.html
+++ b/restock_recommender.html
@@ -24,7 +24,7 @@
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         body {

--- a/review_proposal.html
+++ b/review_proposal.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         * {

--- a/scanner.html
+++ b/scanner.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
     
     <style>

--- a/service-worker.js
+++ b/service-worker.js
@@ -44,12 +44,12 @@ const URLS_TO_CACHE = [
   './governor_contributor_admin.html',
   './governor_permissions.html',
   // Scripts
-  './menu.js?v=20260512b',
+  './menu.js?v=20260512c',
   './routes.js',
   './service-worker.js',
   './js/treasury_cache.js',
   './js/dapp_footer_links.js?v=1',
-  './js/notifications.js?v=20260512b',
+  './js/notifications.js?v=20260512c',
   './scripts/dao_members_cache.js',
   './scripts/permissions.js',
   // External libraries

--- a/shipping_planner.html
+++ b/shipping_planner.html
@@ -53,7 +53,7 @@
     </script>
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCS5tz9sp9mWG6d_glVO19UUk8ZyZ3LdbQ&callback=onGoogleMapsReady&v=weekly&loading=async&libraries=places"></script>
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./js/treasury_cache.js"></script>
     

--- a/store_interaction_history.html
+++ b/store_interaction_history.html
@@ -20,7 +20,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/stores_by_status.html
+++ b/stores_by_status.html
@@ -15,7 +15,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/stores_nearby.html
+++ b/stores_nearby.html
@@ -45,7 +45,7 @@
     </script>
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBWmnvjWeYIEju0JLbfN-Z09k1HEsXzWe4&callback=onGoogleMapsReady&v=weekly&loading=async&libraries=places"></script>
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
     
     <!-- Leaflet.js for maps (no API key required) -->

--- a/submit_feedback.html
+++ b/submit_feedback.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/update_qr_code.html
+++ b/update_qr_code.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/edgar_payload_helper.js"></script>
 

--- a/verify_request.html
+++ b/verify_request.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512b"></script>
+  <script src="./menu.js?v=20260512c"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/view_inventory_holdings.html
+++ b/view_inventory_holdings.html
@@ -14,7 +14,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./js/treasury_cache.js"></script>
 

--- a/view_open_proposals.html
+++ b/view_open_proposals.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512b"></script>
+    <script src="./menu.js?v=20260512c"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/warmup_review.html
+++ b/warmup_review.html
@@ -15,7 +15,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512b"></script>
+  <script src="./menu.js?v=20260512c"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./scripts/permissions.js"></script>

--- a/withdraw_voting_rights.html
+++ b/withdraw_voting_rights.html
@@ -15,7 +15,7 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512b"></script>
+  <script src="./menu.js?v=20260512c"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {


### PR DESCRIPTION
## Summary
Wires a third notification source — **Partner Stock** — that mirrors the 'Needs Attention' scoring [the parallel Claude session](https://github.com/TrueSightDAO/dapp/blob/main/partner_check_in.html#L455-L555) already shipped inline on `partner_check_in.html`. With this PR, the bell surfaces what the page renders, so the operator gets the same signal without having to open the page.

## What it adds

A `partner_stock` source in `js/notifications.js` that:

- Reads `partners-velocity.json` + `partners-inventory.json` (both static GitHub-hosted JSONs, no GAS dependency)
- Applies the severity rules from `computeAttentionList()` on the page, verbatim:
  - **critical**: `totalInv == 0` → 'out of stock'
  - **warning**: `totalInv <= 3` → 'running low (N left)'
  - **info**: any SKU `last_sale_date > 45d` → 'dormant'
- Filters to retail-type partners only (`Consignment | Wholesale`)
- Surfaces top 4 by severity → alphabetical
- Deep-links to `partner_check_in.html` where the operator can act

Refactored the prior in-file `partners-velocity` cache from a name-only map to the full JSON, since both this source and the existing `partner_followups` source consume it.

## Why this is a separate source (not a replacement)

The bell now has two Partner-related sources:

| Source | Signal type | Data source | Returns null when |
|--------|-------------|-------------|-------------------|
| `partner_followups` | Operator-driven cadence ('I scheduled a check-in for date X') | GAS `list_partners_needing_attention` (Partner Check-ins tab → Next Check-in Date) | No check-ins have matured a Next-Check-in Date |
| `partner_stock` | Business-driven urgency ('stock or velocity says ACT') | velocity + inventory static JSONs | All retail partners have stock + recent sales |

Both can fire on the same partner. That's by design — they represent independent reasons to act. Keeping them separate also means future tuning of one rule doesn't risk dragging the other.

## Cache busting

- `menu.js` bumped to `?v=20260512c` across all 33 pages
- `notifications.js` referenced as `?v=20260512c` in menu.js + service-worker

## Test plan

- [x] Local smoke: notifications.js?v=20260512c serves 200; live inventory JSON returns 23 partners with item data
- [ ] **Operator:** open any DApp page (e.g. `index.html`), confirm the bell badge now reflects stock attention items in addition to whatever the warmup/followups sources surface
- [ ] Click the bell, confirm 'Partner Stock' entry appears with a sublabel like 'N out of stock · M low stock · K dormant' and top 4 partner names visible
- [ ] Click a partner row → lands on `partner_check_in.html`, where the same partner appears in the 'Needs Attention' section (counts and scoring should match exactly since they share the same data + rule)