### PR TITLE
notifications: include AI/Partner Poke in Outbound Review bell count

### DIFF
--- a/batch_qr_generator.html
+++ b/batch_qr_generator.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
     
     <style>

--- a/chat.html
+++ b/chat.html
@@ -22,7 +22,7 @@
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/edgar_payload_helper.js"></script>

--- a/create_proposal.html
+++ b/create_proposal.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         * {

--- a/create_signature.html
+++ b/create_signature.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
   
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512c"></script>
+  <script src="./menu.js?v=20260512d"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/edgar_payload_helper.js"></script>

--- a/currency_conversion.html
+++ b/currency_conversion.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./js/treasury_cache.js"></script>
 

--- a/governor_contributor_admin.html
+++ b/governor_contributor_admin.html
@@ -15,7 +15,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512c"></script>
+  <script src="./menu.js?v=20260512d"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./scripts/permissions.js"></script>

--- a/governor_permissions.html
+++ b/governor_permissions.html
@@ -15,7 +15,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512c"></script>
+  <script src="./menu.js?v=20260512d"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./scripts/permissions.js"></script>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <meta property="og:type" content="website">
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
-  <script src="./menu.js?v=20260512c"></script>
+  <script src="./menu.js?v=20260512d"></script>
   <script src="./tdg_balance.js"></script>
 
   <title>TrueSight DAO - Community Collaboration Tools</title>

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -202,10 +202,12 @@
           var warmup = Number(counts['AI/Warm-up'] || 0);
           var followup = Number(counts['AI/Follow-up'] || 0);
           var replied = Number(counts['AI/Prospect Replied'] || 0);
-          var total = warmup + followup + replied;
+          var poke = Number(counts['AI/Partner Poke'] || 0);
+          var total = warmup + followup + replied + poke;
           if (!total) return null;
           var parts = [];
           if (replied) parts.push(replied + ' prospect replied');
+          if (poke) parts.push(poke + ' partner poke');
           if (followup) parts.push(followup + ' follow-up');
           if (warmup) parts.push(warmup + ' warm-up');
           return {

--- a/menu.js
+++ b/menu.js
@@ -94,7 +94,7 @@
     if (document.getElementById('tsd-notif-script')) return;
     var s = document.createElement('script');
     s.id = 'tsd-notif-script';
-    s.src = './js/notifications.js?v=20260512c';
+    s.src = './js/notifications.js?v=20260512d';
     s.async = true;
     document.head.appendChild(s);
   });

--- a/notarize.html
+++ b/notarize.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512c"></script>
+  <script src="./menu.js?v=20260512d"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/partner_check_in.html
+++ b/partner_check_in.html
@@ -20,7 +20,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         body {

--- a/register_farm.html
+++ b/register_farm.html
@@ -17,7 +17,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512c"></script>
+  <script src="./menu.js?v=20260512d"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/repackaging_planner.html
+++ b/repackaging_planner.html
@@ -11,7 +11,7 @@
   <meta property="og:type" content="website">
   <link rel="icon" type="image/png" href="https://raw.githubusercontent.com/TrueSightDAO/.github/main/assets/20240612_truesight_dao_logo_square.png">
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512c"></script>
+  <script src="./menu.js?v=20260512d"></script>
   <script src="./tdg_balance.js"></script>
   <title>Repackaging Planner - TrueSight DAO</title>
   <style>

--- a/report_asset_receipt.html
+++ b/report_asset_receipt.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/report_capital_injection.html
+++ b/report_capital_injection.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/report_contribution.html
+++ b/report_contribution.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
 

--- a/report_dao_expenses.html
+++ b/report_dao_expenses.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     <script src="./expense-form-utils.js"></script>

--- a/report_inventory_movement.html
+++ b/report_inventory_movement.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     <script src="./scripts/permissions.js"></script>

--- a/report_sales.html
+++ b/report_sales.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     

--- a/report_tree_planting.html
+++ b/report_tree_planting.html
@@ -17,7 +17,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512c"></script>
+  <script src="./menu.js?v=20260512d"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/restock_recommender.html
+++ b/restock_recommender.html
@@ -24,7 +24,7 @@
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         body {

--- a/review_proposal.html
+++ b/review_proposal.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         * {

--- a/scanner.html
+++ b/scanner.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
     
     <style>

--- a/service-worker.js
+++ b/service-worker.js
@@ -44,12 +44,12 @@ const URLS_TO_CACHE = [
   './governor_contributor_admin.html',
   './governor_permissions.html',
   // Scripts
-  './menu.js?v=20260512c',
+  './menu.js?v=20260512d',
   './routes.js',
   './service-worker.js',
   './js/treasury_cache.js',
   './js/dapp_footer_links.js?v=1',
-  './js/notifications.js?v=20260512c',
+  './js/notifications.js?v=20260512d',
   './scripts/dao_members_cache.js',
   './scripts/permissions.js',
   // External libraries

--- a/shipping_planner.html
+++ b/shipping_planner.html
@@ -53,7 +53,7 @@
     </script>
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCS5tz9sp9mWG6d_glVO19UUk8ZyZ3LdbQ&callback=onGoogleMapsReady&v=weekly&loading=async&libraries=places"></script>
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./js/treasury_cache.js"></script>
     

--- a/store_interaction_history.html
+++ b/store_interaction_history.html
@@ -20,7 +20,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/stores_by_status.html
+++ b/stores_by_status.html
@@ -15,7 +15,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/stores_nearby.html
+++ b/stores_nearby.html
@@ -45,7 +45,7 @@
     </script>
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBWmnvjWeYIEju0JLbfN-Z09k1HEsXzWe4&callback=onGoogleMapsReady&v=weekly&loading=async&libraries=places"></script>
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
     
     <!-- Leaflet.js for maps (no API key required) -->

--- a/submit_feedback.html
+++ b/submit_feedback.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/update_qr_code.html
+++ b/update_qr_code.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/edgar_payload_helper.js"></script>
 

--- a/verify_request.html
+++ b/verify_request.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512c"></script>
+  <script src="./menu.js?v=20260512d"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/view_inventory_holdings.html
+++ b/view_inventory_holdings.html
@@ -14,7 +14,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./js/treasury_cache.js"></script>
 

--- a/view_open_proposals.html
+++ b/view_open_proposals.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512c"></script>
+    <script src="./menu.js?v=20260512d"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/warmup_review.html
+++ b/warmup_review.html
@@ -15,7 +15,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512c"></script>
+  <script src="./menu.js?v=20260512d"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./scripts/permissions.js"></script>

--- a/withdraw_voting_rights.html
+++ b/withdraw_voting_rights.html
@@ -15,7 +15,7 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512c"></script>
+  <script src="./menu.js?v=20260512d"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {


### PR DESCRIPTION
Small follow-up to dapp PR #242: ensure the bell's Outbound Review count includes the new AI/Partner Poke cohort, so the badge total reflects everything in warmup_review.html (now 4 cohorts).

Null-safe — if the GAS isn't pushed yet, count is 0 and the badge behaves identically to before.

Cache busted: menu.js + notifications.js -> ?v=20260512d across 33 pages.

## Test plan
- [x] All paths serve locally
- [x] menu.js/notifications.js bumped consistently
- [ ] Once tokenomics PR #286 is clasp-pushed: bell badge increments by the partner-poke count; popup sublabel shows '... · N partner poke ...'