### PR TITLE
partner_check_in: extend picker whitelist to include Operator type

### DIFF
--- a/partner_check_in.html
+++ b/partner_check_in.html
@@ -591,7 +591,13 @@
                     setStatus('Could not load partners.', 'error');
                     return;
                 }
-                var RETAIL_TYPES = { 'Consignment': true, 'Wholesale': true };
+                // Partner Check-in surface tracks retail-style relationships AND
+                // operational touchpoints (warehouse managers like Matheus in
+                // Ilhéus, freight providers like Omega Services — partner_type=Operator).
+                // Stock/restock fields are awkward but valid for Operator-type rows;
+                // their follow-up cadence is the load-bearing capability. See
+                // agentic_ai_context/PARTNER_CHECK_IN_IMPLEMENTATION.md §"Dual-use".
+                var RETAIL_TYPES = { 'Consignment': true, 'Wholesale': true, 'Operator': true };
                 var entries = Object.keys(velocity.partners)
                     .filter(function(slug) {
                         if (slug.indexOf('/') !== -1) return false;


### PR DESCRIPTION
Cheap-path extension to let Partner Check-in track operational touchpoints (Matheus — Ilhéus warehouse + freight to SF, partner_type=Operator; Omega Services once added). Two-line change in the picker's allowed-types whitelist. No data migration — Matheus is already in partners-velocity.json as 'black-king-ilheus' / Operator.

The bell's Partner Stock attention source correctly still filters retail-only; non-retail entities surface only via the operator-scheduled cadence (Partner Check-in follow-ups due card). Auto-checkin-on-send v0.1 works identically for Operator-type rows (Stock Status defaults to 'Unknown' which is meaningless but valid).