### PR TITLE
DApp: Freight Provider whitelist + bell per-item deep-links

### DIFF
--- a/batch_qr_generator.html
+++ b/batch_qr_generator.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
     
     <style>

--- a/chat.html
+++ b/chat.html
@@ -22,7 +22,7 @@
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/edgar_payload_helper.js"></script>

--- a/create_proposal.html
+++ b/create_proposal.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         * {

--- a/create_signature.html
+++ b/create_signature.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
   
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512d"></script>
+  <script src="./menu.js?v=20260512e"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/edgar_payload_helper.js"></script>

--- a/currency_conversion.html
+++ b/currency_conversion.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./js/treasury_cache.js"></script>
 

--- a/governor_contributor_admin.html
+++ b/governor_contributor_admin.html
@@ -15,7 +15,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512d"></script>
+  <script src="./menu.js?v=20260512e"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./scripts/permissions.js"></script>

--- a/governor_permissions.html
+++ b/governor_permissions.html
@@ -15,7 +15,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512d"></script>
+  <script src="./menu.js?v=20260512e"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./scripts/permissions.js"></script>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <meta property="og:type" content="website">
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
-  <script src="./menu.js?v=20260512d"></script>
+  <script src="./menu.js?v=20260512e"></script>
   <script src="./tdg_balance.js"></script>
 
   <title>TrueSight DAO - Community Collaboration Tools</title>

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -96,6 +96,11 @@
       '  .tsd-notif-entry-sub { font-size: 0.8125rem; color: #6f6859; margin-top: 0.15rem; }',
       '  .tsd-notif-items { margin: 0.4rem 0 0 0; padding: 0; list-style: none; font-size: 0.8125rem; color: #6f6859; }',
       '  .tsd-notif-items li { padding: 0.15rem 0; }',
+      '  .tsd-notif-entry-header { background: #faf7f1; }',
+      '  .tsd-notif-entry-item { display: flex; justify-content: space-between; align-items: baseline; padding: 0.45rem 1.1rem; font-size: 0.875rem; color: #2a2a2a; gap: 0.5rem; }',
+      '  .tsd-notif-entry-item:hover { background: #faf7f1; }',
+      '  .tsd-notif-item-title { font-weight: 500; flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }',
+      '  .tsd-notif-item-since { font-size: 0.75rem; color: #8a8275; flex: 0 0 auto; }',
       '</style>',
       '<button id="tsd-notif-btn" type="button" aria-label="Notifications" aria-haspopup="true" aria-expanded="false">',
       '  <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2a7 7 0 0 0-7 7v3.586l-1.707 1.707A1 1 0 0 0 4 16h16a1 1 0 0 0 .707-1.707L19 12.586V9a7 7 0 0 0-7-7zm0 20a3 3 0 0 0 3-3H9a3 3 0 0 0 3 3z"/></svg>',
@@ -152,25 +157,28 @@
       html.push('<div class="tsd-notif-empty">No pending action items.</div>');
     } else {
       entries.forEach(function (r) {
-        var itemsHtml = '';
-        if (Array.isArray(r.items) && r.items.length) {
-          itemsHtml = '<ul class="tsd-notif-items">' +
-            r.items.slice(0, 4).map(function (it) {
-              return '<li>' + escapeHtml(it.title || '') +
-                (it.since ? ' · <em>' + escapeHtml(it.since) + '</em>' : '') +
-                '</li>';
-            }).join('') +
-            '</ul>';
-        }
+        // Module header — clickable, leads to the module's index/landing.
         html.push(
-          '<a class="tsd-notif-entry" href="' + escapeAttr(r.link || '#') + '">' +
+          '<a class="tsd-notif-entry tsd-notif-entry-header" href="' + escapeAttr(r.link || '#') + '">' +
             '<div class="tsd-notif-entry-title"><span>' + escapeHtml(r.label || '') + '</span>' +
               '<span class="tsd-notif-entry-count">' + r.count + '</span>' +
             '</div>' +
             (r.sublabel ? '<div class="tsd-notif-entry-sub">' + escapeHtml(r.sublabel) + '</div>' : '') +
-            itemsHtml +
           '</a>'
         );
+        // Per-item rows — each its own clickable <a> with optional deep-link.
+        // Items with no item-level link fall back to the module's link.
+        if (Array.isArray(r.items) && r.items.length) {
+          r.items.slice(0, 4).forEach(function (it) {
+            var itemLink = it.link || r.link || '#';
+            html.push(
+              '<a class="tsd-notif-entry tsd-notif-entry-item" href="' + escapeAttr(itemLink) + '">' +
+                '<span class="tsd-notif-item-title">' + escapeHtml(it.title || '') + '</span>' +
+                (it.since ? '<span class="tsd-notif-item-since">' + escapeHtml(it.since) + '</span>' : '') +
+              '</a>'
+            );
+          });
+        }
       });
     }
     popup.innerHTML = html.join('');
@@ -325,7 +333,11 @@
             else if (days > 0) since = days + 'd overdue';
             else if (days === 0) since = 'due today';
             else since = 'due in ' + (-days) + 'd';
-            return { title: name, since: since };
+            return {
+              title: name,
+              since: since,
+              link: pid ? './partner_check_in.html?partner_id=' + encodeURIComponent(pid) : './partner_check_in.html'
+            };
           });
 
           var overdueCount = partners.filter(function (p) {
@@ -444,7 +456,11 @@
             sublabel: subParts.join(' · '),
             link: './partner_check_in.html',
             items: attention.slice(0, 4).map(function (a) {
-              return { title: a.name, since: a.reasons[0] };
+              return {
+                title: a.name,
+                since: a.reasons[0],
+                link: a.slug ? './partner_check_in.html?partner_id=' + encodeURIComponent(a.slug) : './partner_check_in.html'
+              };
             })
           };
         })

--- a/menu.js
+++ b/menu.js
@@ -94,7 +94,7 @@
     if (document.getElementById('tsd-notif-script')) return;
     var s = document.createElement('script');
     s.id = 'tsd-notif-script';
-    s.src = './js/notifications.js?v=20260512d';
+    s.src = './js/notifications.js?v=20260512e';
     s.async = true;
     document.head.appendChild(s);
   });

--- a/notarize.html
+++ b/notarize.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512d"></script>
+  <script src="./menu.js?v=20260512e"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/partner_check_in.html
+++ b/partner_check_in.html
@@ -20,7 +20,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         body {
@@ -593,11 +593,17 @@
                 }
                 // Partner Check-in surface tracks retail-style relationships AND
                 // operational touchpoints (warehouse managers like Matheus in
-                // Ilhéus, freight providers like Omega Services — partner_type=Operator).
-                // Stock/restock fields are awkward but valid for Operator-type rows;
+                // Ilhéus — partner_type=Operator; freight providers like
+                // Isis @ Omega Services — partner_type=Freight Provider).
+                // Stock/restock fields are awkward but valid for these rows;
                 // their follow-up cadence is the load-bearing capability. See
                 // agentic_ai_context/PARTNER_CHECK_IN_IMPLEMENTATION.md §"Dual-use".
-                var RETAIL_TYPES = { 'Consignment': true, 'Wholesale': true, 'Operator': true };
+                var RETAIL_TYPES = {
+                  'Consignment':     true,
+                  'Wholesale':       true,
+                  'Operator':        true,  // warehouse managers (Matheus)
+                  'Freight Provider': true  // cargo forwarding (Omega Services / Isis)
+                };
                 var entries = Object.keys(velocity.partners)
                     .filter(function(slug) {
                         if (slug.indexOf('/') !== -1) return false;

--- a/register_farm.html
+++ b/register_farm.html
@@ -17,7 +17,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512d"></script>
+  <script src="./menu.js?v=20260512e"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/repackaging_planner.html
+++ b/repackaging_planner.html
@@ -11,7 +11,7 @@
   <meta property="og:type" content="website">
   <link rel="icon" type="image/png" href="https://raw.githubusercontent.com/TrueSightDAO/.github/main/assets/20240612_truesight_dao_logo_square.png">
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512d"></script>
+  <script src="./menu.js?v=20260512e"></script>
   <script src="./tdg_balance.js"></script>
   <title>Repackaging Planner - TrueSight DAO</title>
   <style>

--- a/report_asset_receipt.html
+++ b/report_asset_receipt.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/report_capital_injection.html
+++ b/report_capital_injection.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/report_contribution.html
+++ b/report_contribution.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
 

--- a/report_dao_expenses.html
+++ b/report_dao_expenses.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     <script src="./expense-form-utils.js"></script>

--- a/report_inventory_movement.html
+++ b/report_inventory_movement.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     <script src="./scripts/permissions.js"></script>

--- a/report_sales.html
+++ b/report_sales.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/dao_members_cache.js"></script>
     

--- a/report_tree_planting.html
+++ b/report_tree_planting.html
@@ -17,7 +17,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512d"></script>
+  <script src="./menu.js?v=20260512e"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/restock_recommender.html
+++ b/restock_recommender.html
@@ -24,7 +24,7 @@
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         body {

--- a/review_proposal.html
+++ b/review_proposal.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
     <style>
         * {

--- a/scanner.html
+++ b/scanner.html
@@ -15,7 +15,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
     
     <style>

--- a/service-worker.js
+++ b/service-worker.js
@@ -44,12 +44,12 @@ const URLS_TO_CACHE = [
   './governor_contributor_admin.html',
   './governor_permissions.html',
   // Scripts
-  './menu.js?v=20260512d',
+  './menu.js?v=20260512e',
   './routes.js',
   './service-worker.js',
   './js/treasury_cache.js',
   './js/dapp_footer_links.js?v=1',
-  './js/notifications.js?v=20260512d',
+  './js/notifications.js?v=20260512e',
   './scripts/dao_members_cache.js',
   './scripts/permissions.js',
   // External libraries

--- a/shipping_planner.html
+++ b/shipping_planner.html
@@ -53,7 +53,7 @@
     </script>
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCS5tz9sp9mWG6d_glVO19UUk8ZyZ3LdbQ&callback=onGoogleMapsReady&v=weekly&loading=async&libraries=places"></script>
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./js/treasury_cache.js"></script>
     

--- a/store_interaction_history.html
+++ b/store_interaction_history.html
@@ -20,7 +20,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/stores_by_status.html
+++ b/stores_by_status.html
@@ -15,7 +15,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/stores_nearby.html
+++ b/stores_nearby.html
@@ -45,7 +45,7 @@
     </script>
     <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBWmnvjWeYIEju0JLbfN-Z09k1HEsXzWe4&callback=onGoogleMapsReady&v=weekly&loading=async&libraries=places"></script>
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
     
     <!-- Leaflet.js for maps (no API key required) -->

--- a/submit_feedback.html
+++ b/submit_feedback.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/update_qr_code.html
+++ b/update_qr_code.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./scripts/edgar_payload_helper.js"></script>
 

--- a/verify_request.html
+++ b/verify_request.html
@@ -16,7 +16,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512d"></script>
+  <script src="./menu.js?v=20260512e"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {

--- a/view_inventory_holdings.html
+++ b/view_inventory_holdings.html
@@ -14,7 +14,7 @@
 
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
     <script src="./js/treasury_cache.js"></script>
 

--- a/view_open_proposals.html
+++ b/view_open_proposals.html
@@ -16,7 +16,7 @@
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
     <script src="./routes.js"></script>
-    <script src="./menu.js?v=20260512d"></script>
+    <script src="./menu.js?v=20260512e"></script>
     <script src="./tdg_balance.js"></script>
 
     <style>

--- a/warmup_review.html
+++ b/warmup_review.html
@@ -15,7 +15,7 @@
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">
 
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512d"></script>
+  <script src="./menu.js?v=20260512e"></script>
   <script src="./tdg_balance.js"></script>
   <script src="./scripts/dao_members_cache.js"></script>
   <script src="./scripts/permissions.js"></script>

--- a/withdraw_voting_rights.html
+++ b/withdraw_voting_rights.html
@@ -15,7 +15,7 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="https://github.com/TrueSightDAO/.github/blob/main/assets/20240612_truesight_dao_logo_square.png?raw=true">    
   <script src="./routes.js"></script>
-  <script src="./menu.js?v=20260512d"></script>
+  <script src="./menu.js?v=20260512e"></script>
   <script src="./tdg_balance.js"></script>
   <style>
     body {


### PR DESCRIPTION
Three small Partner Check-in / bell polishings:

1. Whitelist 'Freight Provider' on the picker (so Isis @ Omega Services becomes pickable once velocity JSON refreshes)
2. Partner Check-in bell items get per-item deep-links to ?partner_id=<slug>
3. Partner Stock bell items get the same treatment
4. Popup renderer restructured so each item row is independently clickable

Cache bumped to ?v=20260512e.